### PR TITLE
feat(billing): redesign Plan Management with Complete/Shield tiers

### DIFF
--- a/app/src/components/dashboard/HistoryTab.tsx
+++ b/app/src/components/dashboard/HistoryTab.tsx
@@ -11,6 +11,7 @@ import { PremiumShell, MentorAvatar, ProBadge, injectPremiumStyles } from '../ui
 interface Props {
   familyId: string
   child: ChildRecord
+  childCount: number
   onCountChange: (n: number) => void
   /** Reserved for next iteration — real goal progress data */
   goalProgress?: { goalName: string; choresRemaining: number } | null
@@ -25,7 +26,7 @@ const STATUS_STYLES: Record<string, { label: string; bg: string; text: string }>
   suggestion: { label: 'Suggestion', bg: 'bg-blue-100',   text: 'text-blue-700' },
 }
 
-export function ActivityTab({ familyId, child, onCountChange, goalProgress }: Props) {
+export function ActivityTab({ familyId, child, childCount, onCountChange, goalProgress }: Props) {
   // ── Pending completions (absorbed from PendingTab) ───────────────────────────
   const { challenge, GatekeeperModal } = useGatekeeper()
   const [completions,         setCompletions]         = useState<Completion[]>([])
@@ -271,7 +272,7 @@ export function ActivityTab({ familyId, child, onCountChange, goalProgress }: Pr
 
       {/* ── AI Mentor empty-state card (shown only when no pending approvals) ── */}
       {!pendingLoading && completions.length === 0 && (
-        <MentorEmptyCard childName={child.display_name} goalProgress={goalProgress ?? null} />
+        <MentorEmptyCard childName={child.display_name} childCount={childCount} goalProgress={goalProgress ?? null} />
       )}
 
       {/* ── Pay out bottom sheet ──────────────────────────────────────────────── */}
@@ -504,14 +505,20 @@ interface GoalProgress {
 
 function MentorEmptyCard({
   childName,
+  childCount,
   goalProgress,
 }: {
   childName: string
+  childCount: number
   goalProgress: GoalProgress | null
 }) {
+  const heading = `${childName} is all caught up! 🎉`
+
   const mentorLine = goalProgress
     ? `It looks like ${childName} is ${goalProgress.choresRemaining} chore${goalProgress.choresRemaining !== 1 ? 's' : ''} away from their '${goalProgress.goalName}' goal.`
-    : `Keep an eye on ${childName}'s progress — their next goal milestone is coming up soon.`
+    : childCount === 1
+      ? `Keep an eye on ${childName}'s progress — their next goal milestone is coming up soon.`
+      : `No pending tasks for ${childName} right now. Check the other children's tabs for any outstanding approvals.`
 
   return (
     <PremiumShell>
@@ -527,7 +534,7 @@ function MentorEmptyCard({
                 <span className="inline-block w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse" />
               </div>
               <p className="text-[15px] font-extrabold tracking-tight" style={{ color: '#f0fdf4' }}>
-                The kids are all caught up! 🎉
+                {heading}
               </p>
             </div>
           </div>

--- a/app/src/components/settings/sections/BillingSettings.tsx
+++ b/app/src/components/settings/sections/BillingSettings.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useState, useEffect } from 'react'
-import { CreditCard, Clock, Receipt, Zap, Shield, ChevronRight } from 'lucide-react'
+import { CreditCard, Clock, Receipt, Zap, Shield, ChevronRight, Star, X, Check } from 'lucide-react'
 import { Toast, SettingsRow, SectionCard, SectionHeader } from '../shared'
 import {
   getTrialStatus, getBillingHistory, createCheckoutSession,
@@ -40,8 +40,107 @@ function formatDate(iso: string): string {
 }
 
 const PLAN_LABELS: Record<string, string> = {
-  LIFETIME:  'Lifetime Tracker',
-  AI_ANNUAL: 'AI Coach — Annual',
+  LIFETIME:  'Complete — Lifetime',
+  COMPLETE:  'Complete — Lifetime',
+  AI_ANNUAL: 'AI Mentor — Annual',
+  SHIELD:    'Shield — Lifetime',
+}
+
+// ── Compare Plans modal ────────────────────────────────────────────────────────
+
+const COMPARE_ROWS: { feature: string; free: boolean; complete: boolean; shield: boolean }[] = [
+  { feature: 'Chore tracking & ledger',    free: true,  complete: true,  shield: true  },
+  { feature: 'Child 6-digit code access',  free: true,  complete: true,  shield: true  },
+  { feature: 'Savings goals (Savings Grove)', free: true, complete: true, shield: true },
+  { feature: 'Payment bridge (Monzo etc.)', free: true, complete: true,  shield: true  },
+  { feature: 'Parent insights AI',         free: false, complete: true,  shield: true  },
+  { feature: 'Rate Guide benchmarking',    free: false, complete: true,  shield: true  },
+  { feature: 'Unlimited children',         free: false, complete: true,  shield: true  },
+  { feature: 'AI Mentor add-on eligible',  free: false, complete: true,  shield: true  },
+  { feature: 'Tamper-evident PDF exports',        free: false, complete: false, shield: true  },
+  { feature: 'Digital tamper-seal on every export', free: false, complete: false, shield: true },
+  { feature: 'Co-parent verified sharing',          free: false, complete: false, shield: true },
+]
+
+function ComparePlansModal({ onClose }: { onClose: () => void }) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-lg bg-[var(--color-surface)] rounded-t-2xl pb-safe overflow-hidden shadow-2xl"
+        onClick={e => e.stopPropagation()}
+        style={{ maxHeight: '85vh' }}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 pt-5 pb-4 border-b border-[var(--color-border)]">
+          <div>
+            <p className="text-[16px] font-bold text-[var(--color-text)]">Compare Plans</p>
+            <p className="text-[12px] text-[var(--color-text-muted)] mt-0.5">Do you need your records to be verifiable?</p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="w-8 h-8 rounded-full flex items-center justify-center bg-[var(--color-surface-alt)] text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors"
+          >
+            <X size={15} />
+          </button>
+        </div>
+
+        {/* Column headers */}
+        <div className="grid grid-cols-4 gap-0 px-5 pt-3 pb-2">
+          <div className="col-span-1" />
+          <div className="text-center">
+            <p className="text-[10px] font-bold text-[var(--color-text-muted)] uppercase tracking-wide">Free</p>
+            <p className="text-[11px] font-semibold text-[var(--color-text)] mt-0.5">Trial</p>
+          </div>
+          <div className="text-center">
+            <p className="text-[10px] font-bold text-teal-600 uppercase tracking-wide">Complete</p>
+            <p className="text-[11px] font-semibold text-[var(--color-text)] mt-0.5">£44.99</p>
+          </div>
+          <div className="text-center">
+            <p className="text-[10px] font-bold text-amber-600 uppercase tracking-wide">Shield</p>
+            <p className="text-[11px] font-semibold text-[var(--color-text)] mt-0.5">£149.99</p>
+          </div>
+        </div>
+
+        {/* Rows */}
+        <div className="overflow-y-auto px-5 pb-6" style={{ maxHeight: '55vh' }}>
+          {COMPARE_ROWS.map(row => (
+            <div key={row.feature} className="grid grid-cols-4 gap-0 py-2.5 border-b border-[var(--color-border)] last:border-0 items-center">
+              <p className="col-span-1 text-[12px] text-[var(--color-text)] pr-2 leading-snug">{row.feature}</p>
+              <div className="flex justify-center">
+                {row.free
+                  ? <Check size={14} className="text-teal-500" />
+                  : <span className="w-3.5 h-px bg-[var(--color-border)] block mt-1.5" />}
+              </div>
+              <div className="flex justify-center">
+                {row.complete
+                  ? <Check size={14} className="text-teal-500" />
+                  : <span className="w-3.5 h-px bg-[var(--color-border)] block mt-1.5" />}
+              </div>
+              <div className="flex justify-center">
+                {row.shield
+                  ? <Check size={14} className="text-amber-500" />
+                  : <span className="w-3.5 h-px bg-[var(--color-border)] block mt-1.5" />}
+              </div>
+            </div>
+          ))}
+
+          {/* Mediation anchor + AI footnote */}
+          <div className="mt-4 space-y-2">
+            <p className="text-[11px] text-amber-700 bg-amber-50 rounded-lg px-3 py-2 leading-relaxed font-medium">
+              UK family mediation averages £140/hr. Shield is a one-time £149.99.
+            </p>
+            <p className="text-[11px] text-[var(--color-text-muted)] leading-relaxed">
+              AI Mentor (£19.99/yr) is an optional add-on for Complete and Shield holders — see below.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
 }
 
 // ── Trial sub-view ─────────────────────────────────────────────────────────────
@@ -153,9 +252,10 @@ function TrialView({ onBack }: { onBack: () => void }) {
 // ── Plan management sub-view ───────────────────────────────────────────────────
 
 function PlanView({ onBack, showToast }: { onBack: () => void; showToast: (m: string) => void }) {
-  const [trial, setTrial]     = useState<TrialStatus | null>(null)
-  const [loading, setLoading]  = useState(true)
-  const [buying, setBuying]    = useState<string | null>(null)
+  const [trial, setTrial]         = useState<TrialStatus | null>(null)
+  const [loading, setLoading]     = useState(true)
+  const [buying, setBuying]       = useState<string | null>(null)
+  const [showCompare, setShowCompare] = useState(false)
 
   useEffect(() => {
     getTrialStatus()
@@ -163,7 +263,7 @@ function PlanView({ onBack, showToast }: { onBack: () => void; showToast: (m: st
       .finally(() => setLoading(false))
   }, [])
 
-  async function handleUpgrade(type: 'LIFETIME' | 'AI_ANNUAL') {
+  async function handleUpgrade(type: 'COMPLETE' | 'SHIELD' | 'AI_ANNUAL') {
     setBuying(type)
     try {
       const { url } = await createCheckoutSession(type)
@@ -175,121 +275,242 @@ function PlanView({ onBack, showToast }: { onBack: () => void; showToast: (m: st
     }
   }
 
+  const isLifetime = trial?.has_lifetime_license
+  const isShield   = trial?.has_shield
+  const isAI       = trial?.ai_subscription_active
+
   return (
-    <div className="space-y-4">
-      <SectionHeader title="Plan Management" onBack={onBack} />
+    <>
+      {showCompare && <ComparePlansModal onClose={() => setShowCompare(false)} />}
 
-      {loading ? (
-        <div className="h-40 rounded-xl bg-[var(--color-surface-alt)] animate-pulse" />
-      ) : (
-        <>
-          {/* Current plan status */}
-          <SectionCard>
-            <div className="px-4 py-3">
-              <p className="text-[11px] font-semibold text-[var(--color-text-muted)] uppercase tracking-wide mb-2">
-                Current plan
-              </p>
-              <div className="flex items-center gap-2">
-                <span className={cn(
-                  'inline-block px-2.5 py-1 rounded-full text-[12px] font-bold',
-                  trial?.has_lifetime_license
-                    ? 'bg-[color-mix(in_srgb,var(--brand-primary)_12%,transparent)] text-[var(--brand-primary)]'
-                    : trial?.ai_subscription_active
-                    ? 'bg-violet-100 text-violet-700'
-                    : trial?.is_expired
-                    ? 'bg-red-100 text-red-600'
-                    : 'bg-teal-100 text-teal-700',
-                )}>
-                  {trial?.has_lifetime_license
-                    ? 'Lifetime Tracker'
-                    : trial?.ai_subscription_active
-                    ? 'AI Coach Annual'
-                    : trial?.is_expired
-                    ? 'Trial expired'
-                    : trial?.is_activated
-                    ? `Trial — ${trial.days_remaining ?? 0} days left`
-                    : 'Free trial (not started)'}
-                </span>
-              </div>
-            </div>
-          </SectionCard>
+      <div className="space-y-4">
+        <SectionHeader title="Plan Management" onBack={onBack} />
 
-          {/* Upgrade options — only shown when not on lifetime */}
-          {!trial?.has_lifetime_license && (
+        {loading ? (
+          <div className="space-y-3">
+            <div className="h-16 rounded-xl bg-[var(--color-surface-alt)] animate-pulse" />
+            <div className="h-48 rounded-xl bg-[var(--color-surface-alt)] animate-pulse" />
+          </div>
+        ) : (
+          <>
+            {/* Current plan status */}
             <SectionCard>
-              <div className="px-4 pt-3 pb-1">
+              <div className="px-4 py-3">
                 <p className="text-[11px] font-semibold text-[var(--color-text-muted)] uppercase tracking-wide mb-2">
-                  Upgrade
+                  Current plan
+                </p>
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span className={cn(
+                    'inline-block px-2.5 py-1 rounded-full text-[12px] font-bold',
+                    isShield
+                      ? 'bg-amber-100 text-amber-700'
+                      : isLifetime
+                      ? 'bg-[color-mix(in_srgb,var(--brand-primary)_12%,transparent)] text-[var(--brand-primary)]'
+                      : isAI
+                      ? 'bg-violet-100 text-violet-700'
+                      : trial?.is_expired
+                      ? 'bg-red-100 text-red-600'
+                      : 'bg-teal-100 text-teal-700',
+                  )}>
+                    {isShield
+                      ? 'Shield — Lifetime'
+                      : isLifetime
+                      ? 'Complete — Lifetime'
+                      : isAI
+                      ? 'AI Mentor Annual'
+                      : trial?.is_expired
+                      ? 'Trial expired'
+                      : trial?.is_activated
+                      ? `Trial — ${trial.days_remaining ?? 0} days left`
+                      : 'Free trial (not started)'}
+                  </span>
+                  {isAI && (
+                    <span className="inline-block px-2 py-0.5 rounded-full text-[11px] font-semibold bg-violet-100 text-violet-600">
+                      + AI Mentor
+                    </span>
+                  )}
+                </div>
+              </div>
+            </SectionCard>
+
+            {/* Upgrade options */}
+            {!isShield && (
+              <div className="space-y-3">
+                <div className="flex items-center justify-between px-1">
+                  <p className="text-[11px] font-semibold text-[var(--color-text-muted)] uppercase tracking-wide">
+                    Upgrade
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => setShowCompare(true)}
+                    className="text-[12px] font-semibold text-[var(--brand-primary)] hover:opacity-75 transition-opacity"
+                  >
+                    Why professionals prefer Shield
+                  </button>
+                </div>
+
+                {/* Complete plan */}
+                {!isLifetime && (
+                  <div className="rounded-2xl border-2 border-[var(--color-border)] overflow-hidden relative">
+                    {/* Best Value badge */}
+                    <div className="absolute top-3 right-3 flex items-center gap-1 px-2 py-0.5 rounded-full bg-teal-500 text-white text-[10px] font-bold">
+                      <Star size={9} />
+                      Best Value
+                    </div>
+
+                    <div className="px-4 pt-4 pb-3">
+                      <div className="flex items-start gap-3">
+                        <span className="shrink-0 w-9 h-9 rounded-xl flex items-center justify-center bg-[color-mix(in_srgb,var(--brand-primary)_12%,transparent)] text-[var(--brand-primary)]">
+                          <Shield size={16} />
+                        </span>
+                        <div className="flex-1 min-w-0 pr-16">
+                          <p className="text-[15px] font-bold text-[var(--color-text)]">Complete</p>
+                          <p className="text-[20px] font-bold text-[var(--brand-primary)] leading-none mt-0.5">
+                            £44.99
+                            <span className="text-[12px] font-semibold text-[var(--color-text-muted)] ml-1">one-time</span>
+                          </p>
+                        </div>
+                      </div>
+
+                      <ul className="mt-3 space-y-1.5">
+                        {[
+                          'Secure your family\'s ledger with one payment — no renewals, ever',
+                          'Unlimited children, unlimited chores',
+                          'Parent Insights AI included',
+                          'Rate Guide benchmarking for fair chore pricing',
+                          'AI Mentor add-on available (£19.99/yr)',
+                        ].map(item => (
+                          <li key={item} className="flex items-start gap-2">
+                            <Check size={12} className="shrink-0 text-teal-500 mt-0.5" />
+                            <span className="text-[12px] text-[var(--color-text-muted)] leading-snug">{item}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+
+                    <div className="px-4 pb-4">
+                      <button
+                        type="button"
+                        disabled={buying !== null}
+                        onClick={() => handleUpgrade('COMPLETE')}
+                        className="w-full py-2.5 rounded-xl bg-[var(--brand-primary)] text-white text-[13px] font-bold hover:opacity-90 active:opacity-80 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+                      >
+                        {buying === 'COMPLETE' ? 'Loading…' : 'Get Lifetime Access'}
+                      </button>
+                    </div>
+                  </div>
+                )}
+
+                {/* Shield plan */}
+                <div className="rounded-2xl border-2 border-amber-300 overflow-hidden bg-[color-mix(in_srgb,#f59e0b_6%,var(--color-surface))] shadow-[0_0_0_4px_color-mix(in_srgb,#f59e0b_8%,transparent)]">
+                  <div className="px-4 pt-4 pb-3">
+                    <div className="flex items-start gap-3">
+                      <span className="shrink-0 w-9 h-9 rounded-xl flex items-center justify-center bg-amber-100 text-amber-600">
+                        <Shield size={16} />
+                      </span>
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2">
+                          <p className="text-[15px] font-bold text-[var(--color-text)]">Shield</p>
+                          <span className="px-1.5 py-0.5 rounded-md bg-amber-100 text-amber-700 text-[10px] font-bold uppercase tracking-wide">Professional</span>
+                        </div>
+                        <p className="text-[20px] font-bold text-amber-600 leading-none mt-0.5">
+                          £149.99
+                          <span className="text-[12px] font-semibold text-[var(--color-text-muted)] ml-1">one-time</span>
+                        </p>
+                        <p className="text-[11px] text-amber-700 font-medium mt-1">
+                          Less than one hour of professional mediation
+                        </p>
+                      </div>
+                    </div>
+
+                    <p className="mt-2 mb-3 text-[12px] text-[var(--color-text-muted)] leading-snug">
+                      Every export comes with a digital tamper-seal. If a single number is changed after export, the seal breaks — proving the record is authentic.
+                    </p>
+                    <ul className="space-y-1.5">
+                      {[
+                        'Everything in Complete',
+                        'Tamper-evident PDF exports designed for professional review',
+                        'Digital seal on every export — any change breaks it',
+                        'Share verified records with co-parents, mediators, or solicitors',
+                        'Professional-grade exports your whole family can rely on',
+                      ].map(item => (
+                        <li key={item} className="flex items-start gap-2">
+                          <Check size={12} className="shrink-0 text-amber-500 mt-0.5" />
+                          <span className="text-[12px] text-[var(--color-text-muted)] leading-snug">{item}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+
+                  <div className="px-4 pb-4">
+                    <button
+                      type="button"
+                      disabled={buying !== null}
+                      onClick={() => handleUpgrade('SHIELD')}
+                      className="w-full py-2.5 rounded-xl bg-amber-500 text-white text-[13px] font-bold hover:opacity-90 active:opacity-80 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {buying === 'SHIELD' ? 'Loading…' : 'Get Shield Protection'}
+                    </button>
+                  </div>
+                </div>
+
+              </div>
+            )}
+
+            {/* ── Optional Family Add-Ons ────────────────────────────────────── */}
+            {!isAI && (
+              <div className="space-y-2">
+                <p className="text-[11px] font-semibold text-[var(--color-text-muted)] uppercase tracking-wide px-1">
+                  Optional Family Add-Ons
+                </p>
+                <div className="rounded-2xl border border-[var(--color-border)] overflow-hidden bg-[color-mix(in_srgb,#7c3aed_3%,var(--color-surface))]">
+                  <div className="flex items-start gap-3 px-4 pt-4 pb-3">
+                    <span className="shrink-0 w-9 h-9 rounded-xl flex items-center justify-center bg-violet-100 text-violet-600">
+                      <Zap size={16} />
+                    </span>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-baseline gap-2 flex-wrap">
+                        <p className="text-[14px] font-bold text-[var(--color-text)]">AI Mentor</p>
+                        <span className="text-[13px] font-bold text-violet-600">£19.99 / yr</span>
+                      </div>
+                      <p className="text-[12px] text-[var(--color-text-muted)] mt-0.5 leading-snug">
+                        Help your children build healthy money habits with a dedicated 24/7 AI coach — lessons grounded in their real earnings data.
+                      </p>
+                      {!isLifetime && !isShield && (
+                        <p className="text-[11px] text-violet-600 font-medium mt-1.5">
+                          Available for Complete and Shield members.
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                  {(isLifetime || isShield) && (
+                    <div className="px-4 pb-4">
+                      <button
+                        type="button"
+                        disabled={buying !== null}
+                        onClick={() => handleUpgrade('AI_ANNUAL')}
+                        className="w-full py-2.5 rounded-xl bg-violet-500 text-white text-[13px] font-bold hover:opacity-90 active:opacity-80 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+                      >
+                        {buying === 'AI_ANNUAL' ? 'Loading…' : 'Add AI Mentor — £19.99/yr'}
+                      </button>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+
+            <SectionCard>
+              <div className="px-4 py-3">
+                <p className="text-[12px] text-[var(--color-text-muted)] leading-relaxed">
+                  Payments are processed securely by Stripe. Your card details are never stored by Morechard.
+                  To cancel a subscription contact support.
                 </p>
               </div>
-
-              {/* Lifetime Tracker */}
-              <button
-                type="button"
-                disabled={buying !== null}
-                onClick={() => handleUpgrade('LIFETIME')}
-                className="w-full flex items-start gap-3 px-4 py-3.5 text-left border-b border-[var(--color-border)] hover:bg-[var(--color-surface-alt)] active:bg-[var(--color-surface-alt)] cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                <span className="shrink-0 w-8 h-8 rounded-xl flex items-center justify-center bg-[color-mix(in_srgb,var(--brand-primary)_12%,transparent)] text-[var(--brand-primary)]">
-                  <Shield size={15} />
-                </span>
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2">
-                    <p className="text-[14px] font-semibold text-[var(--color-text)]">Lifetime Tracker</p>
-                    <span className="text-[11px] font-bold text-[var(--brand-primary)]">£34.99</span>
-                  </div>
-                  <p className="text-[12px] text-[var(--color-text-muted)] mt-0.5 leading-snug">
-                    Full access forever — no subscription, no renewals
-                  </p>
-                </div>
-                {buying === 'LIFETIME' ? (
-                  <span className="shrink-0 text-[11px] text-[var(--color-text-muted)] animate-pulse">Loading…</span>
-                ) : (
-                  <ChevronRight size={15} className="shrink-0 text-[var(--color-text-muted)]" />
-                )}
-              </button>
-
-              {/* AI Coach Annual — only if not already subscribed */}
-              {!trial?.ai_subscription_active && (
-                <button
-                  type="button"
-                  disabled={buying !== null}
-                  onClick={() => handleUpgrade('AI_ANNUAL')}
-                  className="w-full flex items-start gap-3 px-4 py-3.5 text-left hover:bg-[var(--color-surface-alt)] active:bg-[var(--color-surface-alt)] cursor-pointer transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  <span className="shrink-0 w-8 h-8 rounded-xl flex items-center justify-center bg-violet-100 text-violet-700">
-                    <Zap size={15} />
-                  </span>
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2">
-                      <p className="text-[14px] font-semibold text-[var(--color-text)]">AI Coach</p>
-                      <span className="text-[11px] font-bold text-violet-600">£19.99 / yr</span>
-                    </div>
-                    <p className="text-[12px] text-[var(--color-text-muted)] mt-0.5 leading-snug">
-                      Personalised financial coaching for your children
-                    </p>
-                  </div>
-                  {buying === 'AI_ANNUAL' ? (
-                    <span className="shrink-0 text-[11px] text-[var(--color-text-muted)] animate-pulse">Loading…</span>
-                  ) : (
-                    <ChevronRight size={15} className="shrink-0 text-[var(--color-text-muted)]" />
-                  )}
-                </button>
-              )}
             </SectionCard>
-          )}
-
-          <SectionCard>
-            <div className="px-4 py-3">
-              <p className="text-[12px] text-[var(--color-text-muted)] leading-relaxed">
-                Payments are processed securely by Stripe. Your card details are never stored by Morechard.
-                To cancel a subscription contact support.
-              </p>
-            </div>
-          </SectionCard>
-        </>
-      )}
-    </div>
+          </>
+        )}
+      </div>
+    </>
   )
 }
 

--- a/app/src/components/settings/sections/BillingSettings.tsx
+++ b/app/src/components/settings/sections/BillingSettings.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useState, useEffect } from 'react'
-import { CreditCard, Clock, Receipt, Zap, Shield, ChevronRight, Star, X, Check } from 'lucide-react'
+import { CreditCard, Clock, Receipt, Zap, Shield, Star, X, Check } from 'lucide-react'
 import { Toast, SettingsRow, SectionCard, SectionHeader } from '../shared'
 import {
   getTrialStatus, getBillingHistory, createCheckoutSession,

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -220,7 +220,7 @@ export async function getTrialStatus(): Promise<TrialStatus> {
 }
 
 export interface PaymentRecord {
-  payment_type: 'LIFETIME' | 'AI_ANNUAL'
+  payment_type: 'LIFETIME' | 'AI_ANNUAL' | 'COMPLETE' | 'SHIELD'
   amount_paid_int: number
   currency: string
   created_at: string
@@ -230,7 +230,7 @@ export async function getBillingHistory(): Promise<{ payments: PaymentRecord[] }
   return request('/api/billing/history')
 }
 
-export async function createCheckoutSession(payment_type: 'LIFETIME' | 'AI_ANNUAL'): Promise<{ url: string }> {
+export async function createCheckoutSession(payment_type: 'LIFETIME' | 'AI_ANNUAL' | 'COMPLETE' | 'SHIELD'): Promise<{ url: string }> {
   return request('/api/stripe/create-checkout', {
     method: 'POST',
     body: JSON.stringify({ payment_type }),

--- a/app/src/screens/ParentDashboard.tsx
+++ b/app/src/screens/ParentDashboard.tsx
@@ -320,7 +320,7 @@ export function ParentDashboard() {
         {!childrenLoaded ? null : activeChild ? (
           <>
             {tab === 'chores'   && <ChoresTab       familyId={familyId} child={activeChild} children={children} />}
-            {tab === 'activity' && <ActivityTab     familyId={familyId} child={activeChild} onCountChange={setPendingCount} />}
+            {tab === 'activity' && <ActivityTab     familyId={familyId} child={activeChild} childCount={children.length} onCountChange={setPendingCount} />}
             {tab === 'pool'     && (
               <PoolTab
                 familyId={familyId}

--- a/docs/superpowers/plans/2026-04-23-family-aware-ai-mentor.md
+++ b/docs/superpowers/plans/2026-04-23-family-aware-ai-mentor.md
@@ -1,0 +1,924 @@
+# Family-Aware AI Mentor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every AI-generated and fallback string in the Morechard mentor dynamically adjust to the actual family composition (child count, parent count, parenting mode) queried from D1 at call time.
+
+**Architecture:** A new `FamilyContext` object is built once per AI call from three parallel D1 queries and injected into every system prompt as a `FAMILY CONTEXT` block with explicit phrasing rules. The rule-based fallback (`buildRuleBasedBriefing`) receives the same object so both the AI path and the fallback path are family-aware. The client-side `MentorEmptyCard` empty-state already receives `childCount` and just needs its body copy updated.
+
+**Tech Stack:** TypeScript, Cloudflare Workers, Cloudflare D1 (SQLite), React (TSX), OpenAI gpt-4o-mini
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `worker/src/types.ts` | Add `FamilyContext` interface |
+| `worker/src/lib/intelligence.ts` | Add `getFamilyContext()` export |
+| `worker/src/routes/chat.ts` | Thread `FamilyContext` through prompt builders; add `FAMILY CONTEXT` block + sibling rules |
+| `worker/src/routes/insights.ts` | Thread `FamilyContext` through `generateBriefing` + `buildRuleBasedBriefing`; update all 8 fallback branches; add collaboration nudge |
+| `app/src/components/dashboard/HistoryTab.tsx` | `MentorEmptyCard` body copy already correct — verify only |
+
+---
+
+## Task 1: Add `FamilyContext` to `worker/src/types.ts`
+
+**Files:**
+- Modify: `worker/src/types.ts`
+
+- [ ] **Step 1: Add the interface after the existing `ParentingMode` type**
+
+Open `worker/src/types.ts`. After line 52 (`export type ParentingMode = 'single' | 'co-parenting';`), insert:
+
+```typescript
+export interface FamilyContext {
+  parenting_mode:   'single' | 'co-parenting';
+  child_count:      number;
+  child_names:      string[];    // first names of all children
+  parent_names:     string[];    // first names of lead + all co-parents
+  family_name:      string;      // families.name fallback: "the family"
+  co_parent_active: boolean;     // both parents approved ≥1 chore in last 30d
+  approval_skew:    number | null; // % of approvals by most-active parent (last 30d); null when single or <5 approvals
+  has_shield:       boolean;     // Shield plan active — suppresses collaboration nudges
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd "worker" && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add worker/src/types.ts
+git commit -m "feat(types): add FamilyContext interface"
+```
+
+---
+
+## Task 2: Add `getFamilyContext()` to `worker/src/lib/intelligence.ts`
+
+**Files:**
+- Modify: `worker/src/lib/intelligence.ts`
+
+- [ ] **Step 1: Add the import**
+
+At the top of `intelligence.ts`, the import line already reads:
+```typescript
+import type { D1Database } from '@cloudflare/workers-types'
+import type { ChildIntelligence, Currency, Locale } from '../types.js'
+```
+
+Change it to:
+```typescript
+import type { D1Database } from '@cloudflare/workers-types'
+import type { ChildIntelligence, Currency, Locale, FamilyContext } from '../types.js'
+```
+
+- [ ] **Step 2: Add `getFamilyContext()` at the bottom of the file, after `detectScrambler`**
+
+Append to the end of `worker/src/lib/intelligence.ts`:
+
+```typescript
+// ─────────────────────────────────────────────────────────────────
+// Family Context — queried fresh on every AI call (not cached)
+// ─────────────────────────────────────────────────────────────────
+
+export async function getFamilyContext(
+  db: D1Database,
+  familyId: string,
+): Promise<FamilyContext> {
+  const THIRTY_DAYS = 30 * 86_400
+  const cutoff = Math.floor(Date.now() / 1000) - THIRTY_DAYS
+
+  const [familyRow, parentRows, childRows, approvalRows] = await Promise.all([
+    // 1. Family metadata
+    db
+      .prepare(`SELECT parenting_mode, name, has_shield FROM families WHERE id = ?`)
+      .bind(familyId)
+      .first<{ parenting_mode: string; name: string | null; has_shield: number }>(),
+
+    // 2. Parent names (lead + co_parent roles)
+    db
+      .prepare(`
+        SELECT u.display_name
+        FROM   family_roles fr
+        JOIN   users u ON u.id = fr.user_id
+        WHERE  fr.family_id = ?
+          AND  fr.role = 'parent'
+        ORDER  BY CASE fr.parent_role WHEN 'lead' THEN 0 ELSE 1 END
+      `)
+      .bind(familyId)
+      .all<{ display_name: string }>(),
+
+    // 3. Child names
+    db
+      .prepare(`
+        SELECT display_name FROM users
+        WHERE  family_id = ? AND role = 'child'
+        ORDER  BY created_at ASC
+      `)
+      .bind(familyId)
+      .all<{ display_name: string }>(),
+
+    // 4. Approval counts per parent in last 30d (for skew + active detection)
+    db
+      .prepare(`
+        SELECT authorised_by, COUNT(*) AS cnt
+        FROM   ledger
+        WHERE  family_id = ?
+          AND  entry_type = 'credit'
+          AND  authorised_by IS NOT NULL
+          AND  created_at >= ?
+        GROUP  BY authorised_by
+      `)
+      .bind(familyId, cutoff)
+      .all<{ authorised_by: string; cnt: number }>(),
+  ])
+
+  // ── Derive values ──────────────────────────────────────────────
+  const parenting_mode = (familyRow?.parenting_mode ?? 'single') as 'single' | 'co-parenting'
+  const has_shield     = Boolean(familyRow?.has_shield)
+  const family_name    = familyRow?.name?.trim() || 'the family'
+
+  const parent_names = (parentRows.results ?? [])
+    .map(r => r.display_name.split(' ')[0] || '')
+    .filter(Boolean)
+
+  const child_names = (childRows.results ?? [])
+    .map(r => r.display_name.split(' ')[0] || '')
+    .filter(Boolean)
+
+  const child_count = Math.max(1, child_names.length)
+
+  // Approval skew: % held by the single most-active parent
+  const approvals = approvalRows.results ?? []
+  const totalApprovals = approvals.reduce((s, r) => s + r.cnt, 0)
+
+  let approval_skew: number | null = null
+  let co_parent_active = false
+
+  if (parenting_mode === 'co-parenting' && totalApprovals >= 5) {
+    const maxApprovals = Math.max(...approvals.map(r => r.cnt))
+    approval_skew = Math.round((maxApprovals / totalApprovals) * 100)
+    // Both parents active = at least 2 distinct approvers with ≥1 approval each
+    co_parent_active = approvals.length >= 2
+  }
+
+  return {
+    parenting_mode,
+    child_count,
+    child_names,
+    parent_names,
+    family_name,
+    co_parent_active,
+    approval_skew,
+    has_shield,
+  }
+}
+```
+
+- [ ] **Step 3: Type-check**
+
+```bash
+cd "worker" && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add worker/src/lib/intelligence.ts
+git commit -m "feat(intelligence): add getFamilyContext() — parallel D1 queries for family composition"
+```
+
+---
+
+## Task 3: Thread `FamilyContext` through `chat.ts`
+
+**Files:**
+- Modify: `worker/src/routes/chat.ts`
+
+This task has three sub-steps: (a) import + query, (b) update `buildSystemPrompt` signature, (c) update each locale prompt builder.
+
+- [ ] **Step 1: Update the import in `chat.ts`**
+
+Change the existing import from `../types.js`:
+```typescript
+import type { Env } from '../types.js'
+import type { ChildIntelligence, FinancialPillar, MentorResponse } from '../types.js'
+```
+to:
+```typescript
+import type { Env } from '../types.js'
+import type { ChildIntelligence, FamilyContext, FinancialPillar, MentorResponse } from '../types.js'
+```
+
+And update the intelligence import to include `getFamilyContext`:
+```typescript
+import { getChildIntelligence, getFamilyContext } from '../lib/intelligence.js'
+```
+
+- [ ] **Step 2: Query `FamilyContext` in `handleChildChat`**
+
+Inside `handleChildChat`, find the existing intelligence query:
+```typescript
+  const intel = await getChildIntelligence(env.DB, auth.sub)
+  if (!intel) {
+    return json({ error: 'Child profile not found' }, 404)
+  }
+```
+
+Replace with:
+```typescript
+  const [intel, familyCtx] = await Promise.all([
+    getChildIntelligence(env.DB, auth.sub),
+    getFamilyContext(env.DB, auth.family_id).catch(() => null),
+  ])
+  if (!intel) {
+    return json({ error: 'Child profile not found' }, 404)
+  }
+  // Guaranteed non-null — use safe defaults if DB query failed
+  const resolvedFamilyCtx: FamilyContext = familyCtx ?? {
+    parenting_mode:   'single',
+    child_count:      1,
+    child_names:      [intel.display_name.split(' ')[0]],
+    parent_names:     [],
+    family_name:      'the family',
+    co_parent_active: false,
+    approval_skew:    null,
+    has_shield:       false,
+  }
+```
+
+- [ ] **Step 3: Pass `resolvedFamilyCtx` to `buildSystemPrompt` and `selectPillar`**
+
+Find:
+```typescript
+  const pillar = selectPillar(intel, userMessage)
+  const systemPrompt = buildSystemPrompt(intel, pillar)
+```
+
+Replace with:
+```typescript
+  const pillar = selectPillar(intel, userMessage)
+  const systemPrompt = buildSystemPrompt(intel, pillar, resolvedFamilyCtx)
+```
+
+- [ ] **Step 4: Update `buildSystemPrompt` signature**
+
+Find:
+```typescript
+function buildSystemPrompt(intel: ChildIntelligence, pillar: FinancialPillar): string {
+  switch (intel.locale) {
+    case 'en-US': return buildUSPrompt(intel, pillar)
+    case 'pl':    return buildPLPrompt(intel, pillar)
+    default:      return buildUKPrompt(intel, pillar)
+  }
+}
+```
+
+Replace with:
+```typescript
+function buildSystemPrompt(intel: ChildIntelligence, pillar: FinancialPillar, familyCtx: FamilyContext): string {
+  switch (intel.locale) {
+    case 'en-US': return buildUSPrompt(intel, pillar, familyCtx)
+    case 'pl':    return buildPLPrompt(intel, pillar, familyCtx)
+    default:      return buildUKPrompt(intel, pillar, familyCtx)
+  }
+}
+```
+
+- [ ] **Step 5: Add `buildFamilyContextBlock()` helper — insert before `buildSystemPrompt`**
+
+```typescript
+// ── Family Context block — injected at the top of every child-chat system prompt ──
+
+function buildFamilyContextBlock(familyCtx: FamilyContext, currentChildName: string, locale: string): string {
+  const isPl = locale === 'pl'
+  const siblings = familyCtx.child_names.filter(n => n !== currentChildName)
+  const hasSiblings = familyCtx.child_count > 1 && siblings.length > 0
+
+  const siblingBlock = hasSiblings
+    ? (isPl
+        ? `ZASADY DOTYCZĄCE RODZEŃSTWA (obowiązkowe):
+- Możesz wspomnieć o rodzeństwie WYŁĄCZNIE przy wspólnych rodzinnych kamieniach milowych lub niezależnych świętowaniach (np. "Świetny tydzień dla Sadu!").
+- Zakaz porównywania postępów. Zakaz ujawniania celów, kwot ani postępów rodzeństwa.
+- Pozytywne nastawienie: świętuj wspólnie, nigdy nie porównuj.
+- Imiona rodzeństwa: ${siblings.join(', ')}.`
+        : `SIBLING RULES (mandatory):
+- Reference siblings ONLY for shared family milestones or independent celebrations (e.g. "Great week for the Orchard!").
+- Never compare progress. Never disclose another child's goal name, target amount, or progress percentage.
+- Positive-only: celebrate together, never benchmark.
+- Sibling name(s): ${siblings.join(', ')}.`)
+    : ''
+
+  if (isPl) {
+    return `KONTEKST RODZINNY:
+- Tryb rodzicielski: ${familyCtx.parenting_mode === 'co-parenting' ? 'współrodzicielstwo' : 'jeden rodzic'}
+- Liczba dzieci w rodzinie: ${familyCtx.child_count}
+- Nazwa rodziny: ${familyCtx.family_name}
+${hasSiblings ? siblingBlock : '- To jedyne dziecko w tej rodzinie. Nie wspominaj o rodzeństwie.'}`
+  }
+
+  return `FAMILY CONTEXT:
+- Parenting mode: ${familyCtx.parenting_mode}
+- Number of children in this family: ${familyCtx.child_count}
+- Family name: ${familyCtx.family_name}
+${hasSiblings ? siblingBlock : '- This is the only child in this family. Do not reference siblings.'}`
+}
+```
+
+- [ ] **Step 6: Update `buildUKPrompt` to accept and inject `familyCtx`**
+
+Find:
+```typescript
+function buildUKPrompt(intel: ChildIntelligence, pillar: FinancialPillar): string {
+```
+
+Replace with:
+```typescript
+function buildUKPrompt(intel: ChildIntelligence, pillar: FinancialPillar, familyCtx: FamilyContext): string {
+```
+
+Then find the `return` statement at the top of `buildUKPrompt` (the line starting with `` return `You are the Orchard Mentor ``). Prepend the family context block to the returned string by replacing:
+
+```typescript
+  return `You are the Orchard Mentor — a warm, collaborative financial coach for UK children.
+```
+
+with:
+
+```typescript
+  const familyBlock = buildFamilyContextBlock(familyCtx, intel.display_name.split(' ')[0], intel.locale)
+
+  return `${familyBlock}
+
+You are the Orchard Mentor — a warm, collaborative financial coach for UK children.
+```
+
+- [ ] **Step 7: Update `buildUSPrompt` to accept and inject `familyCtx`**
+
+Find:
+```typescript
+function buildUSPrompt(intel: ChildIntelligence, pillar: FinancialPillar): string {
+```
+
+Replace with:
+```typescript
+function buildUSPrompt(intel: ChildIntelligence, pillar: FinancialPillar, familyCtx: FamilyContext): string {
+```
+
+Find the `return` statement in `buildUSPrompt` (the line starting with `` return `You are the Performance Coach ``). Replace:
+
+```typescript
+  return `You are the Performance Coach — a direct, outcome-focused financial mentor for US children.
+```
+
+with:
+
+```typescript
+  const familyBlock = buildFamilyContextBlock(familyCtx, intel.display_name.split(' ')[0], intel.locale)
+
+  return `${familyBlock}
+
+You are the Performance Coach — a direct, outcome-focused financial mentor for US children.
+```
+
+- [ ] **Step 8: Update `buildPLPrompt` to accept and inject `familyCtx`**
+
+Find:
+```typescript
+function buildPLPrompt(intel: ChildIntelligence, pillar: FinancialPillar): string {
+```
+
+Replace with:
+```typescript
+function buildPLPrompt(intel: ChildIntelligence, pillar: FinancialPillar, familyCtx: FamilyContext): string {
+```
+
+Find the `return` statement in `buildPLPrompt` (the line starting with `` return `Jesteś Mistrzem Sadu ``). Replace:
+
+```typescript
+  return `Jesteś Mistrzem Sadu — formalnym, bezpośrednim mentorem finansowym dla polskich dzieci.
+```
+
+with:
+
+```typescript
+  const familyBlock = buildFamilyContextBlock(familyCtx, intel.display_name.split(' ')[0], intel.locale)
+
+  return `${familyBlock}
+
+Jesteś Mistrzem Sadu — formalnym, bezpośrednim mentorem finansowym dla polskich dzieci.
+```
+
+- [ ] **Step 9: Type-check**
+
+```bash
+cd "worker" && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add worker/src/routes/chat.ts worker/src/lib/intelligence.ts
+git commit -m "feat(chat): inject FamilyContext into all locale system prompts with sibling rules"
+```
+
+---
+
+## Task 4: Thread `FamilyContext` through `insights.ts`
+
+**Files:**
+- Modify: `worker/src/routes/insights.ts`
+
+This is the largest task. It has four sub-steps: (a) import + query, (b) update `BriefingInput` + `buildSystemPrompt`, (c) update `buildRuleBasedBriefing` all 8 branches, (d) add collaboration nudge.
+
+- [ ] **Step 1: Update imports in `insights.ts`**
+
+Find the existing import:
+```typescript
+import { Env } from '../types.js';
+```
+
+Replace with:
+```typescript
+import { Env, FamilyContext } from '../types.js';
+```
+
+Find:
+```typescript
+import { captureAiGeneration } from '../lib/posthog.js';
+```
+
+Add after it:
+```typescript
+import { getFamilyContext } from '../lib/intelligence.js';
+```
+
+- [ ] **Step 2: Query `FamilyContext` in `handleInsights`**
+
+Inside `handleInsights`, find the section after the effectiveChildId check (around line 46). Find:
+```typescript
+  const periodStart = getPeriodStart(period);
+  const now         = Math.floor(Date.now() / 1000);
+```
+
+Replace with:
+```typescript
+  const periodStart = getPeriodStart(period);
+  const now         = Math.floor(Date.now() / 1000);
+
+  // Family context — queried fresh, not cached
+  const familyCtx = await getFamilyContext(env.DB, family_id).catch((): FamilyContext => ({
+    parenting_mode:   'single',
+    child_count:      1,
+    child_names:      [],
+    parent_names:     [],
+    family_name:      'the family',
+    co_parent_active: false,
+    approval_skew:    null,
+    has_shield:       false,
+  }));
+```
+
+- [ ] **Step 3: Add `FamilyContext` to `BriefingInput`**
+
+Find the `BriefingInput` interface:
+```typescript
+interface BriefingInput {
+  consistencyScore:       number | null;
+  firstTimePassRate:      number | null;
+  planningHorizon:        number | null;
+  trends:                 ReturnType<typeof buildTrends>;
+  velocityContext:        { mode: 'seedling'; avg_tasks_per_week: number } | { mode: 'professional'; avg_earned_pence_week: number };
+  effortPreference:       'high_yield' | 'steady' | null;
+  availableBalancePence:  number;
+  goalsLockedPence:       number;
+  locale:                 'en' | 'pl';
+  childName:              string;
+  honorific:              string;
+}
+```
+
+Replace with:
+```typescript
+interface BriefingInput {
+  consistencyScore:       number | null;
+  firstTimePassRate:      number | null;
+  planningHorizon:        number | null;
+  trends:                 ReturnType<typeof buildTrends>;
+  velocityContext:        { mode: 'seedling'; avg_tasks_per_week: number } | { mode: 'professional'; avg_earned_pence_week: number };
+  effortPreference:       'high_yield' | 'steady' | null;
+  availableBalancePence:  number;
+  goalsLockedPence:       number;
+  locale:                 'en' | 'pl';
+  childName:              string;
+  honorific:              string;
+  familyCtx:              FamilyContext;
+}
+```
+
+- [ ] **Step 4: Pass `familyCtx` into both briefing call sites in `handleInsights`**
+
+Find the cache-miss call to `generateBriefing`:
+```typescript
+      mentorBriefing = await generateBriefing(env, effectiveChildId, {
+        consistencyScore,
+        firstTimePassRate,
+        planningHorizon,
+        trends,
+        velocityContext,
+        effortPreference,
+        availableBalancePence: Math.max(0, availableBal),
+        goalsLockedPence:      goalsLocked,
+        locale,
+        childName,
+        honorific,
+      });
+```
+
+Replace with:
+```typescript
+      mentorBriefing = await generateBriefing(env, effectiveChildId, {
+        consistencyScore,
+        firstTimePassRate,
+        planningHorizon,
+        trends,
+        velocityContext,
+        effortPreference,
+        availableBalancePence: Math.max(0, availableBal),
+        goalsLockedPence:      goalsLocked,
+        locale,
+        childName,
+        honorific,
+        familyCtx,
+      });
+```
+
+- [ ] **Step 5: Add `buildInsightsFamilyBlock()` helper in `insights.ts`**
+
+Insert this function just before `buildSystemPrompt` in `insights.ts`:
+
+```typescript
+function buildInsightsFamilyBlock(familyCtx: FamilyContext, childName: string, locale: 'en' | 'pl'): string {
+  const isPl = locale === 'pl'
+  const coParentLine = familyCtx.parenting_mode === 'co-parenting' && familyCtx.parent_names.length >= 2
+    ? (isPl
+        ? `Rodzice: ${familyCtx.parent_names.join(' i ')}. Zwracaj się do obojga rodziców, gdy to stosowne.`
+        : `Parents: ${familyCtx.parent_names.join(' and ')}. Address both parents when contextually relevant.`)
+    : (isPl
+        ? 'Rodzina z jednym rodzicem. Nie używaj "oboje rodziców" ani nie wspominaj o współrodzicielstwie.'
+        : 'Single-parent family. Never say "both parents" or reference a co-parent.')
+
+  const siblingLine = familyCtx.child_count > 1
+    ? (isPl
+        ? `Rodzina ma ${familyCtx.child_count} dzieci. Możesz świętować sukcesy całej rodziny (np. "Cały Sad kwitnie"), ale NIGDY nie porównuj postępów dzieci.`
+        : `This family has ${familyCtx.child_count} children. You may celebrate whole-family milestones (e.g. "The whole Orchard is thriving"), but NEVER compare children's progress.`)
+    : (isPl
+        ? `${childName} jest jedynym dzieckiem w tej rodzinie.`
+        : `${childName} is the only child in this family.`)
+
+  const nudgeRule = familyCtx.parenting_mode === 'co-parenting' && !familyCtx.has_shield
+    && familyCtx.co_parent_active && (familyCtx.approval_skew ?? 0) > 80
+    ? (isPl
+        ? 'WSKAZÓWKA WSPÓŁPRACY (dozwolona raz w briefingu): Zauważyliśmy, że ostatnio zatwierdzenia pochodzą głównie od jednego rodzica — partner może chcieć bardziej zaangażować się w tym tygodniu. Ton: obserwacja, nie dyrektywa.'
+        : 'COLLABORATION NUDGE (allowed once in this briefing): We\'ve noticed most approvals have come from one parent recently — your co-parent might enjoy being more involved this week. Tone: observation, never directive.')
+    : ''
+
+  if (isPl) {
+    return `KONTEKST RODZINNY (obowiązkowy):
+- ${coParentLine}
+- ${siblingLine}
+- Nazwa rodziny: ${familyCtx.family_name}
+- ZAKAZ używania "dzieci" (użyj imienia dziecka lub "Twoje dziecko").
+${nudgeRule}`
+  }
+
+  return `FAMILY CONTEXT (mandatory):
+- ${coParentLine}
+- ${siblingLine}
+- Family name: ${familyCtx.family_name}
+- NEVER say "the kids" — use the child's name or "your child".
+${nudgeRule}`
+}
+```
+
+- [ ] **Step 6: Update `buildSystemPrompt` in `insights.ts` to inject the family block**
+
+Find the `buildSystemPrompt` function in `insights.ts` (not the one in `chat.ts` — this one takes `locale`, `isTeenMode`, `childName`, `honorific`):
+
+```typescript
+function buildSystemPrompt(
+  locale: 'en' | 'pl',
+  isTeenMode: boolean,
+  childName: string,
+  honorific: string,
+): string {
+```
+
+Replace with:
+
+```typescript
+function buildSystemPrompt(
+  locale: 'en' | 'pl',
+  isTeenMode: boolean,
+  childName: string,
+  honorific: string,
+  familyCtx: FamilyContext,
+): string {
+```
+
+Then in both the Polish (`if (isPl)`) and English (`return`) return strings, prepend the family block. Find the Polish return:
+
+```typescript
+    return `Jesteś "Mistrzem Sadu" (Mistrz Sadu) — wysokiej klasy konsultantem finansowym dla rodziców. \
+```
+
+Replace with:
+
+```typescript
+    const familyBlock = buildInsightsFamilyBlock(familyCtx, childName, locale)
+    return `${familyBlock}
+
+Jesteś "Mistrzem Sadu" (Mistrz Sadu) — wysokiej klasy konsultantem finansowym dla rodziców. \
+```
+
+Find the English return (near end of `buildSystemPrompt`):
+```typescript
+  // ── English persona: Collaborative Coach (Orchard Lead) ──────────────────
+  return `You are the 'Orchard Lead', a collaborative financial coach for parents. \
+```
+
+Replace with:
+```typescript
+  // ── English persona: Collaborative Coach (Orchard Lead) ──────────────────
+  const familyBlock = buildInsightsFamilyBlock(familyCtx, childName, locale)
+  return `${familyBlock}
+
+You are the 'Orchard Lead', a collaborative financial coach for parents. \
+```
+
+- [ ] **Step 7: Pass `familyCtx` into `buildSystemPrompt` inside `generateBriefing`**
+
+Find inside `generateBriefing`:
+```typescript
+  const isTeenMode   = input.velocityContext.mode === 'professional';
+  const systemPrompt = buildSystemPrompt(input.locale, isTeenMode, input.childName, input.honorific);
+```
+
+Replace with:
+```typescript
+  const isTeenMode   = input.velocityContext.mode === 'professional';
+  const systemPrompt = buildSystemPrompt(input.locale, isTeenMode, input.childName, input.honorific, input.familyCtx);
+```
+
+- [ ] **Step 8: Update `buildRuleBasedBriefing` to accept and use `familyCtx`**
+
+Find:
+```typescript
+function buildRuleBasedBriefing(input: BriefingInput): MentorBriefing {
+  const {
+    trends, consistencyScore, firstTimePassRate, planningHorizon,
+    velocityContext, availableBalancePence, goalsLockedPence, locale,
+    childName, honorific,
+  } = input;
+```
+
+Replace with:
+```typescript
+function buildRuleBasedBriefing(input: BriefingInput): MentorBriefing {
+  const {
+    trends, consistencyScore, firstTimePassRate, planningHorizon,
+    velocityContext, availableBalancePence, goalsLockedPence, locale,
+    childName, honorific, familyCtx,
+  } = input;
+
+  // Co-parent address string (e.g. "you and Sarah" or "both of you")
+  const coParentName = familyCtx.parenting_mode === 'co-parenting' && familyCtx.parent_names.length >= 2
+    ? familyCtx.parent_names.filter(n => n !== familyCtx.parent_names[0])[0] ?? 'your partner'
+    : null;
+  const parentAddress = coParentName
+    ? (locale === 'pl' ? `Ty i ${coParentName}` : `you and ${coParentName}`)
+    : (locale === 'pl' ? 'Ty' : 'you');
+
+  // Sibling team line for Pillar 5 (positive-only, no comparisons)
+  const siblingTeamLine = familyCtx.child_count > 1
+    ? (locale === 'pl'
+        ? ` Cały Sad ${familyCtx.family_name} kwitnie w tym tygodniu.`
+        : ` The whole ${familyCtx.family_name} Orchard is thriving this week.`)
+    : '';
+```
+
+- [ ] **Step 9: Update Pillar 5 branch to use `siblingTeamLine` and `parentAddress`**
+
+Find the Pillar 5 block inside `buildRuleBasedBriefing`. It starts with:
+```typescript
+  if (hasSurplus || goalsFunded) {
+```
+
+The `obs` variable in this block currently ends with a period. Update the English `obs` to append `siblingTeamLine`:
+
+Find:
+```typescript
+      : (isPl
+          ? 'Zauważyliśmy, że wszystkie aktywne cele oszczędnościowe zostały w pełni sfinansowane w tym okresie—to ważny kamień milowy w cyklu Zbiorów.'
+          : 'We have observed that all active savings goals have been fully funded this period—a significant milestone in the Harvest cycle.');
+```
+
+Replace with:
+```typescript
+      : (isPl
+          ? `Zauważyliśmy, że wszystkie aktywne cele oszczędnościowe zostały w pełni sfinansowane w tym okresie—to ważny kamień milowy w cyklu Zbiorów.${siblingTeamLine}`
+          : `We have observed that all active savings goals have been fully funded this period—a significant milestone in the Harvest cycle.${siblingTeamLine}`);
+```
+
+And find the `hasSurplus` obs line:
+```typescript
+      ? (isPl
+          ? `Zauważyliśmy, że dostępne saldo przekroczyło ${balanceDisplay}—w Sadzie zgromadził się znaczący nadmiar.`
+          : `We have noted that the available balance has exceeded ${balanceDisplay}—a meaningful surplus has accumulated in the Orchard.`)
+```
+
+Replace with:
+```typescript
+      ? (isPl
+          ? `Zauważyliśmy, że dostępne saldo przekroczyło ${balanceDisplay}—w Sadzie zgromadził się znaczący nadmiar.${siblingTeamLine}`
+          : `We have noted that the available balance has exceeded ${balanceDisplay}—a meaningful surplus has accumulated in the Orchard.${siblingTeamLine}`)
+```
+
+- [ ] **Step 10: Update remaining 7 branches to substitute child name and parent address**
+
+For each remaining branch (Pillar 3, Pillar 1, Pillar 2, Pillar 4, and the default), the `nudge` strings that reference `${childName}` or `${formalAddr}` are already correct (they use the child's name). No change needed there. However each branch's English `obs` currently uses generic "we" which is fine. The only thing to update is: in the Pillar 4 and default branches, if co-parenting, append a single co-parent acknowledgement to the English nudge.
+
+Find the Pillar 4 English seedling nudge:
+```typescript
+          : `You might consider introducing the idea of a "Boost" from a parent as a matching contribution—framing it to ${childName} as "the Orchard growing your seed" makes compound interest intuitive.`
+```
+
+Replace with:
+```typescript
+          : `You might consider ${coParentName ? `${parentAddress} introducing` : 'introducing'} the idea of a "Boost" as a matching contribution—framing it to ${childName} as "the Orchard growing your seed" makes compound interest intuitive.`
+```
+
+Find the Pillar 4 English professional nudge:
+```typescript
+          : `You might consider modelling with ${childName} what a 5% or 10% annual return would look like on their current savings balance—this anchors Pillar 4 in a real number rather than an abstract concept.`
+```
+
+Replace with:
+```typescript
+          : `You might consider ${coParentName ? `${parentAddress} modelling` : 'modelling'} with ${childName} what a 5% or 10% annual return would look like on their current savings balance—this anchors Pillar 4 in a real number rather than an abstract concept.`
+```
+
+- [ ] **Step 11: Add collaboration nudge as post-processing in `buildRuleBasedBriefing`**
+
+The collaboration nudge is suppressed on Shield and when `co_parent_active = false`. Add it as a post-processing step at the very end of `buildRuleBasedBriefing`, just before the final `return` of each branch.
+
+The cleanest approach: wrap the final return value. Find the last line of `buildRuleBasedBriefing` before the closing brace — the default branch return:
+
+```typescript
+  return { observation: obs, behavioral_root: root, the_nudge: nudge, source: 'fallback' };
+}
+```
+
+This is repeated across all branches. Instead of modifying each one, restructure the function to collect into a variable and post-process. Replace every branch's final return:
+
+```typescript
+  return { observation: obs, behavioral_root: root, the_nudge: nudge, source: 'fallback' };
+```
+
+with:
+
+```typescript
+  return applyCollaborationNudge({ observation: obs, behavioral_root: root, the_nudge: nudge, source: 'fallback' }, familyCtx, locale, isSeedling);
+```
+
+Then add this helper function just before `buildRuleBasedBriefing`:
+
+```typescript
+function applyCollaborationNudge(
+  briefing: MentorBriefing,
+  familyCtx: FamilyContext,
+  locale: 'en' | 'pl',
+  isSeedling: boolean,
+): MentorBriefing {
+  const shouldNudge =
+    familyCtx.parenting_mode === 'co-parenting' &&
+    !familyCtx.has_shield &&
+    familyCtx.co_parent_active &&
+    (familyCtx.approval_skew ?? 0) > 80
+
+  if (!shouldNudge) return briefing
+
+  const coParentName = familyCtx.parent_names.length >= 2
+    ? familyCtx.parent_names[1]
+    : (locale === 'pl' ? 'partner' : 'your partner')
+
+  const nudgeSuffix = locale === 'pl'
+    ? ` Zauważyliśmy również, że ostatnio zatwierdzenia pochodzą głównie od jednego rodzica — ${coParentName} może chcieć bardziej zaangażować się w tym tygodniu.`
+    : ` We've also noticed most approvals have come from one parent recently — ${coParentName} might enjoy being more involved this week.`
+
+  return {
+    ...briefing,
+    the_nudge: briefing.the_nudge + nudgeSuffix,
+  }
+}
+```
+
+- [ ] **Step 12: Type-check**
+
+```bash
+cd "worker" && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add worker/src/routes/insights.ts worker/src/lib/intelligence.ts worker/src/types.ts
+git commit -m "feat(insights): inject FamilyContext into parent briefing — family-aware AI + fallback"
+```
+
+---
+
+## Task 5: Verify `HistoryTab.tsx` `MentorEmptyCard`
+
+**Files:**
+- Verify: `app/src/components/dashboard/HistoryTab.tsx`
+
+The `MentorEmptyCard` was already updated in a prior session to receive `childCount` and produce family-aware copy. This task just confirms correctness.
+
+- [ ] **Step 1: Verify the component matches the spec**
+
+Read `app/src/components/dashboard/HistoryTab.tsx` around line 506–549. Confirm:
+
+1. `childCount: number` is in the props interface ✓
+2. `heading` uses `${childName} is all caught up! 🎉` (no "the kids") ✓
+3. Single child body (`childCount === 1`, no `goalProgress`): `"Keep an eye on ${childName}'s progress — their next goal milestone is coming up soon."` ✓
+4. Multi-child body (no `goalProgress`): `"No pending tasks for ${childName} right now. Check the other children's tabs for any outstanding approvals."` ✓
+5. `ActivityTab` passes `childCount={children.length}` from `ParentDashboard.tsx` ✓
+
+- [ ] **Step 2: TypeScript check on the app**
+
+```bash
+cd "app" && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit (only if any correction was needed)**
+
+```bash
+git add app/src/components/dashboard/HistoryTab.tsx app/src/screens/ParentDashboard.tsx
+git commit -m "fix(activity): MentorEmptyCard family-aware copy — name over 'the kids'"
+```
+
+---
+
+## Task 6: Final type-check and integration smoke test
+
+- [ ] **Step 1: Full worker type-check**
+
+```bash
+cd "worker" && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 2: Full app type-check**
+
+```bash
+cd "app" && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Manual scenario walkthrough (no automated tests — runtime is Cloudflare Workers)**
+
+Start the dev server and open the parent dashboard. Confirm all five spec test scenarios produce correct UI copy:
+
+| Scenario | Expected |
+|---|---|
+| Single parent, 1 child | No "the kids", no "both parents", no sibling block in child chat |
+| Co-parenting, 1 child | Co-parent name in briefing, no sibling references |
+| Single parent, 2 children | Sibling team line in child chat, no co-parent language |
+| Co-parenting, 2 children, `approval_skew > 80`, both active | Collaboration nudge appears once in rule-based briefing |
+| Co-parenting, 2 children, one parent inactive | Nudge suppressed |
+
+- [ ] **Step 4: Final commit**
+
+```bash
+git add -A
+git commit -m "feat: family-aware AI mentor — FamilyContext flows through all AI surfaces"
+```

--- a/docs/superpowers/specs/2026-04-23-family-aware-ai-mentor-design.md
+++ b/docs/superpowers/specs/2026-04-23-family-aware-ai-mentor-design.md
@@ -1,0 +1,150 @@
+# Family-Aware AI Mentor — Design Spec
+**Date:** 2026-04-23  
+**Branch:** feat/plan-management-redesign  
+**Status:** Approved for implementation
+
+---
+
+## Problem
+
+Every AI-generated string in the Morechard mentor surfaces assumes a generic family: "The kids are all caught up!", "both parents", sibling-agnostic copy. A family with one child and a single parent sees the same phrasing as a co-parenting household with three children. This breaks the "bespoke household member" positioning that justifies the £19.99/year AI Mentor add-on.
+
+---
+
+## Goal
+
+Make every AI-generated and fallback string dynamically adjust to actual family composition — queried from the DB at call time — with no hardcoded assumptions about child count, parent count, or parenting mode.
+
+---
+
+## Scope
+
+Three surfaces:
+
+1. **`worker/src/lib/intelligence.ts`** — new `getFamilyContext()` export
+2. **`worker/src/routes/chat.ts`** — child chat system prompt
+3. **`worker/src/routes/insights.ts`** — parent briefing (AI + rule-based fallback)
+4. **`app/src/components/dashboard/HistoryTab.tsx`** — empty-state `MentorEmptyCard` (client-side only, no AI call)
+
+---
+
+## The `FamilyContext` Object
+
+```typescript
+interface FamilyContext {
+  parenting_mode:   'single' | 'co-parenting'
+  child_count:      number
+  child_names:      string[]     // first names of all children in the family
+  parent_names:     string[]     // first names of lead + all co-parents
+  family_name:      string       // families.name, e.g. "The Savery Family"
+  co_parent_active: boolean      // both parents approved ≥1 chore in last 30d
+  approval_skew:    number | null // % of approvals by most-active parent (last 30d)
+                                  // null when single parent or <5 total approvals
+}
+```
+
+Built by `getFamilyContext(db: D1Database, familyId: string): Promise<FamilyContext>` in `intelligence.ts`. Three parallel D1 queries:
+
+1. `families` — `parenting_mode`, `name`
+2. `family_roles JOIN users` — parent display names (lead + co_parent roles)
+3. `users WHERE family_id = ? AND role = 'child'` — child display names
+
+**Fallback values when data is missing:**
+
+| Missing data | Fallback string |
+|---|---|
+| Child name | `"your child"` |
+| Co-parent name | `"your partner"` |
+| `family_name` empty | `"the family"` |
+| `child_count = 0` | treat as 1, suppress sibling logic |
+
+---
+
+## System Prompt Injection Rules
+
+`FamilyContext` is serialised as a `FAMILY CONTEXT` block injected at the top of every AI system prompt, before child behavioural data.
+
+### Hard rules — all locales, all surfaces
+
+- **Never say "the kids"** — use child's name or "your child"
+- **Never say "both parents"** when `parenting_mode = 'single'`
+- **No sibling comparisons** — never use one child's progress to benchmark another
+- **No goal specifics across siblings** — reference completion events only ("finished their goal"), never goal names or amounts from another child's record
+- **No age comparisons** — age is not stored; never infer or reference it
+
+### Co-parenting rules (`parenting_mode = 'co-parenting'`)
+
+- Address "both of you" or name both parents when contextually relevant
+- **Collaboration nudge:** if `approval_skew > 80` AND `co_parent_active = true`, surface one soft suggestion per briefing — observation framing only ("We've noticed most approvals have come from one parent recently — your co-parent might enjoy being more involved this week"). Never a directive.
+- **No nudge** when `co_parent_active = false` — avoid implying the absent parent is slacking
+- **Shield plan:** when `has_shield = true`, co-parent names are used consistently and deterministically (feeds audit PDF). Collaboration nudges are suppressed on Shield — audit impartiality requires strictly neutral language.
+
+### Sibling rules — child chat only (`child_count > 1`)
+
+- May reference siblings **only** for shared/team milestones ("great week for the Orchard")
+- Positive-only: celebrate together, never compare
+- Never disclose another child's goal name, target amount, or progress percentage
+- When `child_count = 1`: sibling block omitted from prompt entirely
+
+---
+
+## Surface Changes
+
+### 1. `intelligence.ts` — `getFamilyContext()`
+
+New exported async function. Takes `db` and `familyId`. Runs three parallel queries, returns `FamilyContext`. Called at the top of `handleChildChat` and `handleInsights` alongside existing intelligence queries.
+
+`getChildIntelligence()` signature unchanged — `FamilyContext` is a separate concern and passed independently to prompt builders.
+
+### 2. `chat.ts` — Child Chat
+
+- `handleChildChat` calls `getFamilyContext(env.DB, auth.family_id)` in parallel with `getChildIntelligence`
+- `buildSystemPrompt(intel, pillar)` gains a third parameter: `familyCtx: FamilyContext`
+- Each locale prompt (`buildUKPrompt`, `buildUSPrompt`, `buildPLPrompt`) receives the `FAMILY CONTEXT` block and sibling rules when `child_count > 1`
+- Sibling block is suppressed entirely when `child_count = 1`
+
+### 3. `insights.ts` — Parent Briefing
+
+- `handleInsights` calls `getFamilyContext` in parallel with existing queries
+- `generateBriefing()` and `buildRuleBasedBriefing()` both receive `FamilyContext`
+- `buildSystemPrompt` in insights gains the `FAMILY CONTEXT` block + co-parent phrasing rules
+- All eight `buildRuleBasedBriefing` branches updated: child name substituted, co-parent references added where applicable, Pillar 5 (Social Responsibility) gains a sibling team-line when `child_count > 1` ("The whole Orchard is thriving")
+- Collaboration nudge logic added as a post-processing step on the rule-based fallback (not inside individual branches)
+
+### 4. `HistoryTab.tsx` — `MentorEmptyCard`
+
+Client-side only. No AI call. Already receives `childCount` prop (added in previous session).
+
+- Single child: `"[Name] is all caught up! 🎉"` + personal body copy
+- Multiple children: `"[Name] is all caught up! 🎉"` + team-flavoured body copy referencing the other tabs
+- Body copy when `childCount > 1` and no `goalProgress`: `"No pending tasks for [Name] right now. Check the other children's tabs for any outstanding approvals."`
+
+---
+
+## What Is Not Changed
+
+- `ChildIntelligence` interface — no new fields
+- D1 schema — no new tables or columns
+- The `insight_snapshots` caching logic — `FamilyContext` is not cached (it's lightweight and changes infrequently, but must be fresh)
+- Shield PDF export route — co-parent names already flow from the DB; this spec ensures the AI briefing language matches
+
+---
+
+## Fallback Chain
+
+Every surface has two layers of fallback:
+
+1. **AI call fails → rule-based briefing** — `buildRuleBasedBriefing()` uses `FamilyContext` directly, so it is family-aware by construction
+2. **DB query for `FamilyContext` fails** — defaults kick in (see fallback table above); the call proceeds with safe generic strings rather than crashing
+
+---
+
+## Testing Notes
+
+- Single parent, one child: verify no "the kids", no "both parents", no sibling block
+- Co-parent, one child: verify co-parent name appears, no sibling block
+- Single parent, two children: verify sibling celebration fires in child chat, no co-parent language
+- Co-parent, two children, high `approval_skew`, both active: verify collaboration nudge appears once in briefing
+- Co-parent, two children, one parent inactive: verify nudge is suppressed
+- Shield plan, co-parenting: verify nudge suppressed, co-parent names consistent
+- Missing name in DB: verify fallback string used, no crash

--- a/worker/src/lib/intelligence.ts
+++ b/worker/src/lib/intelligence.ts
@@ -3,7 +3,7 @@
 // for the AI Mentor at chat time. All queries are read-only.
 
 import type { D1Database } from '@cloudflare/workers-types'
-import type { ChildIntelligence, Currency, Locale } from '../types.js'
+import type { ChildIntelligence, Currency, Locale, FamilyContext } from '../types.js'
 
 const DAY_SECONDS = 86_400
 const WEEK_SECONDS = 7 * DAY_SECONDS
@@ -684,4 +684,101 @@ function detectScrambler(days: number[]): {
     return { is_scrambler: true, scrambler_day: DAYS[maxDay] }
   }
   return { is_scrambler: false, scrambler_day: null }
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Family Context — queried fresh on every AI call (not cached)
+// ─────────────────────────────────────────────────────────────────
+
+export async function getFamilyContext(
+  db: D1Database,
+  familyId: string,
+): Promise<FamilyContext> {
+  const THIRTY_DAYS = 30 * 86_400
+  const cutoff = Math.floor(Date.now() / 1000) - THIRTY_DAYS
+
+  const [familyRow, parentRows, childRows, approvalRows] = await Promise.all([
+    // 1. Family metadata
+    db
+      .prepare(`SELECT parenting_mode, name, has_shield FROM families WHERE id = ?`)
+      .bind(familyId)
+      .first<{ parenting_mode: string; name: string | null; has_shield: number }>(),
+
+    // 2. Parent names (lead + co_parent roles)
+    db
+      .prepare(`
+        SELECT u.display_name
+        FROM   family_roles fr
+        JOIN   users u ON u.id = fr.user_id
+        WHERE  fr.family_id = ?
+          AND  fr.role = 'parent'
+        ORDER  BY CASE fr.parent_role WHEN 'lead' THEN 0 ELSE 1 END
+      `)
+      .bind(familyId)
+      .all<{ display_name: string }>(),
+
+    // 3. Child names
+    db
+      .prepare(`
+        SELECT display_name FROM users
+        WHERE  family_id = ? AND role = 'child'
+        ORDER  BY created_at ASC
+      `)
+      .bind(familyId)
+      .all<{ display_name: string }>(),
+
+    // 4. Approval counts per parent in last 30d (for skew + active detection)
+    db
+      .prepare(`
+        SELECT authorised_by, COUNT(*) AS cnt
+        FROM   ledger
+        WHERE  family_id = ?
+          AND  entry_type = 'credit'
+          AND  authorised_by IS NOT NULL
+          AND  created_at >= ?
+        GROUP  BY authorised_by
+      `)
+      .bind(familyId, cutoff)
+      .all<{ authorised_by: string; cnt: number }>(),
+  ])
+
+  // ── Derive values ──────────────────────────────────────────────
+  const parenting_mode = (familyRow?.parenting_mode ?? 'single') as 'single' | 'co-parenting'
+  const has_shield     = Boolean(familyRow?.has_shield)
+  const family_name    = familyRow?.name?.trim() || 'the family'
+
+  const parent_names = (parentRows.results ?? [])
+    .map(r => r.display_name.split(' ')[0] || '')
+    .filter(Boolean)
+
+  const child_names = (childRows.results ?? [])
+    .map(r => r.display_name.split(' ')[0] || '')
+    .filter(Boolean)
+
+  const child_count = Math.max(1, child_names.length)
+
+  // Approval skew: % held by the single most-active parent
+  const approvals = approvalRows.results ?? []
+  const totalApprovals = approvals.reduce((s, r) => s + r.cnt, 0)
+
+  let approval_skew: number | null = null
+  let co_parent_active = false
+
+  if (parenting_mode === 'co-parenting' && totalApprovals >= 5) {
+    const maxApprovals = Math.max(...approvals.map(r => r.cnt))
+    approval_skew = Math.round((maxApprovals / totalApprovals) * 100)
+    // Both parents active = at least 2 distinct approvers with ≥1 approval each
+    co_parent_active = approvals.length >= 2
+  }
+
+  return {
+    parenting_mode,
+    child_count,
+    child_names,
+    parent_names,
+    family_name,
+    co_parent_active,
+    approval_skew,
+    has_shield,
+  }
 }

--- a/worker/src/routes/chat.ts
+++ b/worker/src/routes/chat.ts
@@ -187,6 +187,7 @@ Response length: 2–4 sentences.
 
 CHILD DATA — ground every response in these real numbers, never teach in the abstract:
 - Name: ${intel.display_name}
+- Earnings mode: ${intel.earnings_mode === 'ALLOWANCE' ? 'fixed allowance (not chore-dependent)' : intel.earnings_mode === 'HYBRID' ? 'hybrid (allowance + chores)' : 'chores only'}
 - Balance (their grove): ${balance}${isOrchard ? ` (${choresToPhysical(intel.balance_minor, intel.currency)})` : ''}
 - ${goalLine}
 - ${velocityLine}
@@ -194,8 +195,9 @@ CHILD DATA — ground every response in these real numbers, never teach in the a
 - Chores completed this week: ${intel.completed_7d} of ${intel.assigned_chore_count} assigned
 - Spent this week: ${formatMinor(intel.spent_minor_7d, intel.currency)} (${intel.spend_to_balance_pct}% of balance)
 - Planning horizon: ${intel.planning_horizon_days} days ahead
+${intel.bonus_pence_7d > 0 ? `- Bonus received this week: ${formatMinor(intel.bonus_pence_7d, intel.currency)} (parent recognised something special)` : ''}
 ${scramblerNote}
-${intel.has_parent_message ? `Parent message for ${intel.display_name}: "${intel.parent_message}"` : ''}
+${intel.has_parent_message ? `PARENT MESSAGE (priority — acknowledge this first before any financial topic): "${intel.parent_message}"` : ''}
 ${integrityNote}
 ${batchingNote}
 ${burnerNote}
@@ -267,6 +269,7 @@ Response length: 2–4 sentences.
 
 CHILD DATA — ground every lesson in these real numbers:
 - Name: ${intel.display_name}
+- Earnings mode: ${intel.earnings_mode === 'ALLOWANCE' ? 'fixed allowance — do not suggest "complete more chores to earn faster"' : intel.earnings_mode === 'HYBRID' ? 'hybrid (allowance + chores)' : 'chores only'}
 - Balance: ${balance}
 - ${goalLine}
 - Reliability Rating: ${intel.reliability_rating}% — this is their simulated "Credit Score." Above 90% = eligible for Parental Boost.
@@ -274,7 +277,9 @@ CHILD DATA — ground every lesson in these real numbers:
 - Quality failures (needs revision): ${intel.needs_revision_7d} this week
 - Weekly velocity: ${formatMinor(intel.velocity_7d * 7, intel.currency)} earned
 - Spent this week: ${formatMinor(intel.spent_minor_7d, intel.currency)} (${intel.spend_to_balance_pct}% of balance)
+${intel.bonus_pence_7d > 0 ? `- Bonus received this week: ${formatMinor(intel.bonus_pence_7d, intel.currency)} — parent recognised exceptional effort or behaviour.` : ''}
 ${intel.is_sunday_scrambler ? `- Scrambler alert: ${intel.display_name} batches chores on ${intel.scrambler_day}s — habit distribution opportunity.` : ''}
+${intel.has_parent_message ? `PARENT MESSAGE (priority — acknowledge this first before any financial topic): "${intel.parent_message}"` : ''}
 ${usIntegrityNote}
 ${usBatchingNote}
 ${usBurnerNote}
@@ -353,8 +358,11 @@ DANE DZIECKA — każdą lekcję opieraj na tych konkretnych liczbach:
 - Wskaźnik niezawodności: ${intel.reliability_rating}%
 - Zadania wykonane w tym tygodniu: ${intel.completed_7d} z ${intel.assigned_chore_count}
 - Prędkość zarobków: ${formatMinor(intel.velocity_7d * 7, intel.currency)} w tym tygodniu
+- Tryb zarobków: ${intel.earnings_mode === 'ALLOWANCE' ? 'stałe kieszonkowe (niezależne od zadań — nie sugeruj "wykonaj więcej zadań, aby zarobić więcej")' : intel.earnings_mode === 'HYBRID' ? 'hybrydowy (kieszonkowe + zadania)' : 'tylko zadania'}
 - Wydane w tym tygodniu: ${formatMinor(intel.spent_minor_7d, intel.currency)} (${intel.spend_to_balance_pct}% salda)
+${intel.bonus_pence_7d > 0 ? `- Premia otrzymana w tym tygodniu: ${formatMinor(intel.bonus_pence_7d, intel.currency)} (rodzic wyróżnił coś wyjątkowego — warto to uznać)` : ''}
 ${intel.is_sunday_scrambler ? `- Wzorzec: ${formalAddress} wykonuje większość zadań w ${intel.scrambler_day}. Wymagana jest poprawa planowania.` : ''}
+${intel.has_parent_message ? `WIADOMOŚĆ OD RODZICA (priorytet — odnieś się do niej ZANIM przejdziesz do tematów finansowych): "${intel.parent_message}"` : ''}
 ${intel.consecutive_low_confidence >= 3 ? `WYZWALACZ INTEGRALNOŚCI: Wykryto ${intel.consecutive_low_confidence} kolejne przesłania zdjęć o niskiej wiarygodności. Dostarcz lekcję "Ciężka Praca vs. Skróty." Podejście: autorytatywne, ale konstruktywne. Rama: honor i jakość pracy są fundamentem wiarygodności. NIE używaj słów "oszustwo" ani "złapany." Powiedz: "Dane wskazują, że ostatnie dowody wymagają uwagi."` : ''}
 ${intel.batching_detected ? `WYZWALACZ GRUPOWANIA: Dane EXIF wskazują wykonanie wielu zadań w krótkim czasie. Dostarcz lekcję "Moc Małych Kroków." Rama: regularna praca buduje nawyki i wartość. Użyj analogii sadu — regularne podlewanie vs. jednorazowa powódź. Podejście autorytatywne: "Na podstawie danych, zalecana struktura to codzienna rutyna."` : ''}
 ${plBurnerNote}

--- a/worker/src/routes/chat.ts
+++ b/worker/src/routes/chat.ts
@@ -3,10 +3,10 @@
 // Three locales: UK (Collaborative Coach), US (Performance Coach), PL (Master Mentor / Authority)
 
 import type { Env } from '../types.js'
-import type { ChildIntelligence, FinancialPillar, MentorResponse } from '../types.js'
+import type { ChildIntelligence, FamilyContext, FinancialPillar, MentorResponse } from '../types.js'
 import { json } from '../lib/response.js'
 import type { JwtPayload } from '../lib/jwt.js'
-import { getChildIntelligence } from '../lib/intelligence.js'
+import { getChildIntelligence, getFamilyContext } from '../lib/intelligence.js'
 import { captureAiGeneration } from '../lib/posthog.js'
 
 type AuthedRequest = Request & { auth: JwtPayload }
@@ -77,17 +77,53 @@ function selectPillar(intel: ChildIntelligence, message: string): FinancialPilla
 // System prompt builders — one per locale
 // ─────────────────────────────────────────────────────────────────
 
-function buildSystemPrompt(intel: ChildIntelligence, pillar: FinancialPillar): string {
+// ── Family Context block — injected at the top of every child-chat system prompt ──
+
+function buildFamilyContextBlock(familyCtx: FamilyContext, currentChildName: string, locale: string): string {
+  const isPl = locale === 'pl'
+  const siblings = familyCtx.child_names.filter(n => n !== currentChildName)
+  const hasSiblings = familyCtx.child_count > 1 && siblings.length > 0
+
+  const siblingBlock = hasSiblings
+    ? (isPl
+        ? `ZASADY DOTYCZĄCE RODZEŃSTWA (obowiązkowe):
+- Możesz wspomnieć o rodzeństwie WYŁĄCZNIE przy wspólnych rodzinnych kamieniach milowych lub niezależnych świętowaniach (np. "Świetny tydzień dla Sadu!").
+- Zakaz porównywania postępów. Zakaz ujawniania celów, kwot ani postępów rodzeństwa.
+- Pozytywne nastawienie: świętuj wspólnie, nigdy nie porównuj.
+- Imiona rodzeństwa: ${siblings.join(', ')}.`
+        : `SIBLING RULES (mandatory):
+- Reference siblings ONLY for shared family milestones or independent celebrations (e.g. "Great week for the Orchard!").
+- Never compare progress. Never disclose another child's goal name, target amount, or progress percentage.
+- Positive-only: celebrate together, never benchmark.
+- Sibling name(s): ${siblings.join(', ')}.`)
+    : ''
+
+  if (isPl) {
+    return `KONTEKST RODZINNY:
+- Tryb rodzicielski: ${familyCtx.parenting_mode === 'co-parenting' ? 'współrodzicielstwo' : 'jeden rodzic'}
+- Liczba dzieci w rodzinie: ${familyCtx.child_count}
+- Nazwa rodziny: ${familyCtx.family_name}
+${hasSiblings ? siblingBlock : '- To jedyne dziecko w tej rodzinie. Nie wspominaj o rodzeństwie.'}`
+  }
+
+  return `FAMILY CONTEXT:
+- Parenting mode: ${familyCtx.parenting_mode}
+- Number of children in this family: ${familyCtx.child_count}
+- Family name: ${familyCtx.family_name}
+${hasSiblings ? siblingBlock : '- This is the only child in this family. Do not reference siblings.'}`
+}
+
+function buildSystemPrompt(intel: ChildIntelligence, pillar: FinancialPillar, familyCtx: FamilyContext): string {
   switch (intel.locale) {
-    case 'en-US': return buildUSPrompt(intel, pillar)
-    case 'pl':    return buildPLPrompt(intel, pillar)
-    default:      return buildUKPrompt(intel, pillar)
+    case 'en-US': return buildUSPrompt(intel, pillar, familyCtx)
+    case 'pl':    return buildPLPrompt(intel, pillar, familyCtx)
+    default:      return buildUKPrompt(intel, pillar, familyCtx)
   }
 }
 
 // ── UK: Collaborative Coach (FCA / National Curriculum) ─────────────
 
-function buildUKPrompt(intel: ChildIntelligence, pillar: FinancialPillar): string {
+function buildUKPrompt(intel: ChildIntelligence, pillar: FinancialPillar, familyCtx: FamilyContext): string {
   const isOrchard = intel.app_view === 'ORCHARD'
   const balance = formatMinor(intel.balance_minor, intel.currency)
   const topGoal = intel.goals[0]
@@ -136,7 +172,11 @@ function buildUKPrompt(intel: ChildIntelligence, pillar: FinancialPillar): strin
     ? `DEVICE SWAPPER TRIGGER ACTIVE: ${intel.distinct_ips_7d} different devices/locations detected this week. Deliver the "Digital Safety" lesson — teach about account security, sharing passwords, and recognising phishing. Frame it as a superpower: "Knowing your digital footprint keeps your grove safe."`
     : ''
 
-  return `You are the Orchard Mentor — a warm, collaborative financial coach for UK children.
+  const familyBlock = buildFamilyContextBlock(familyCtx, intel.display_name.split(' ')[0], intel.locale)
+
+  return `${familyBlock}
+
+You are the Orchard Mentor — a warm, collaborative financial coach for UK children.
 
 PERSONA: Supportive Peer / Collaborative Coach. Egalitarian, first-name basis. You are a helpful colleague, NOT an authority figure.
 Tone: Supportive, encouraging, peer-to-peer. Formality: 3/5.
@@ -177,7 +217,7 @@ CHOICE ARCHITECT CONSTRAINT: Never dictate. Present the evidence, then invite ${
 
 // ── US: Performance Coach (Jump$tart / CEE Standards) ───────────────
 
-function buildUSPrompt(intel: ChildIntelligence, pillar: FinancialPillar): string {
+function buildUSPrompt(intel: ChildIntelligence, pillar: FinancialPillar, familyCtx: FamilyContext): string {
   const isOrchard = intel.app_view === 'ORCHARD'
   const balance = formatMinor(intel.balance_minor, intel.currency)
   const topGoal = intel.goals[0]
@@ -213,7 +253,11 @@ function buildUSPrompt(intel: ChildIntelligence, pillar: FinancialPillar): strin
     ? `DEVICE SWAPPER TRIGGER ACTIVE: ${intel.distinct_ips_7d} distinct IPs this week. Deliver the "Digital Safety" lesson — teach about credential security and phishing. Frame it as a financial risk: "Your account is your digital wallet. Protecting it is step one of financial literacy."`
     : ''
 
-  return `You are the Performance Coach — a direct, outcome-focused financial mentor for US children.
+  const familyBlock = buildFamilyContextBlock(familyCtx, intel.display_name.split(' ')[0], intel.locale)
+
+  return `${familyBlock}
+
+You are the Performance Coach — a direct, outcome-focused financial mentor for US children.
 
 PERSONA: Performance Coach. Energetic, achievement-oriented, goal-driven.
 Tone: Friendly but focused on outcomes. Formality: 2/5.
@@ -256,7 +300,7 @@ CHOICE ARCHITECT CONSTRAINT: Show the data, then let ${intel.display_name} make 
 
 // ── PL: Master Mentor (Polish National Financial Education Strategy) ─
 
-function buildPLPrompt(intel: ChildIntelligence, pillar: FinancialPillar): string {
+function buildPLPrompt(intel: ChildIntelligence, pillar: FinancialPillar, familyCtx: FamilyContext): string {
   const isOrchard = intel.app_view === 'ORCHARD'
   // Pan/Pani for CLEAN mode (proxy for 16+ / Mature), first name for younger
   const isMature = intel.app_view === 'CLEAN'
@@ -287,7 +331,11 @@ function buildPLPrompt(intel: ChildIntelligence, pillar: FinancialPillar): strin
     ? `WYZWALACZ BEZPIECZEŃSTWA: ${intel.distinct_ips_7d} różnych adresów IP w ciągu 7 dni. Dostarcz lekcję "Bezpieczeństwo Cyfrowe." Ramka: cyfrowy portfel wymaga ochrony. "Na podstawie danych, konto było używane z wielu lokalizacji. Wymagana weryfikacja bezpieczeństwa — to podstawa cyfrowej odpowiedzialności."`
     : ''
 
-  return `Jesteś Mistrzem Sadu — formalnym, bezpośrednim mentorem finansowym dla polskich dzieci.
+  const familyBlock = buildFamilyContextBlock(familyCtx, intel.display_name.split(' ')[0], intel.locale)
+
+  return `${familyBlock}
+
+Jesteś Mistrzem Sadu — formalnym, bezpośrednim mentorem finansowym dla polskich dzieci.
 
 PERSONA: Mistrz Sadu / Master Mentor. UWAGA: NIE jesteś rówieśnikiem ani przyjacielem. Jesteś AUTORYTETEM i MISTRZEM z doświadczeniem. Twoja rola to INSTRUOWAĆ i PROWADZIĆ z powagą.
 [ENGLISH FOR MODEL CLARITY: You are NOT a peer or friend. You are an Authority Figure and Master Mentor. Your role is to INSTRUCT and GUIDE with the weight of experience. Use declarative statements: "Based on the data, the required action is...", "We recommend the following structure." NOT suggestions like "You might want to..." The UK persona says "We've been thinking about..." (peer suggestion). The PL persona says "Based on the data, the required action is..." (authority directive).]
@@ -517,14 +565,28 @@ export async function handleChildChat(
   const userMessage = body.message.slice(0, 500)
 
   // ── Build intelligence snapshot ────────────────────────────────
-  const intel = await getChildIntelligence(env.DB, auth.sub)
+  const [intel, familyCtx] = await Promise.all([
+    getChildIntelligence(env.DB, auth.sub),
+    getFamilyContext(env.DB, auth.family_id).catch(() => null),
+  ])
   if (!intel) {
     return json({ error: 'Child profile not found' }, 404)
+  }
+  // Safe defaults if DB query failed
+  const resolvedFamilyCtx: FamilyContext = familyCtx ?? {
+    parenting_mode:   'single',
+    child_count:      1,
+    child_names:      [intel.display_name.split(' ')[0]],
+    parent_names:     [],
+    family_name:      'the family',
+    co_parent_active: false,
+    approval_skew:    null,
+    has_shield:       false,
   }
 
   // ── Select Pillar & build system prompt ────────────────────────
   const pillar = selectPillar(intel, userMessage)
-  const systemPrompt = buildSystemPrompt(intel, pillar)
+  const systemPrompt = buildSystemPrompt(intel, pillar, resolvedFamilyCtx)
   const dataPoints = buildDataPoints(intel, pillar)
 
   // ── Call GPT-4o-mini ───────────────────────────────────────────

--- a/worker/src/routes/insights.ts
+++ b/worker/src/routes/insights.ts
@@ -20,10 +20,11 @@
  *   goals_locked_pence      — sum of (target - saved) across active goals
  */
 
-import { Env } from '../types.js';
+import { Env, FamilyContext } from '../types.js';
 import { json, error } from '../lib/response.js';
 import { JwtPayload } from '../lib/jwt.js';
 import { captureAiGeneration } from '../lib/posthog.js';
+import { getFamilyContext } from '../lib/intelligence.js';
 
 type AuthedRequest = Request & { auth: JwtPayload };
 
@@ -47,6 +48,18 @@ export async function handleInsights(request: Request, env: Env): Promise<Respon
 
   const periodStart = getPeriodStart(period);
   const now         = Math.floor(Date.now() / 1000);
+
+  // Family context — queried fresh, not cached
+  const familyCtx = await getFamilyContext(env.DB, family_id).catch((): FamilyContext => ({
+    parenting_mode:   'single',
+    child_count:      1,
+    child_names:      [],
+    parent_names:     [],
+    family_name:      'the family',
+    co_parent_active: false,
+    approval_skew:    null,
+    has_shield:       false,
+  }));
 
   // ── 1. First-Time Pass Rate ───────────────────────────────────────────────
   const passRateRow = await env.DB.prepare(`
@@ -337,6 +350,7 @@ export async function handleInsights(request: Request, env: Env): Promise<Respon
         locale,
         childName,
         honorific,
+        familyCtx,
       });
 
       // Persist to D1 so the next call within this week is instant.
@@ -477,6 +491,49 @@ interface BriefingInput {
   locale:                 'en' | 'pl';
   childName:              string;   // first name only, used for formal Polish address
   honorific:              string;   // 'Pan' | 'Pani' | 'Młody Ekspercie'
+  familyCtx:              FamilyContext;
+}
+
+function buildInsightsFamilyBlock(familyCtx: FamilyContext, childName: string, locale: 'en' | 'pl'): string {
+  const isPl = locale === 'pl'
+  const coParentLine = familyCtx.parenting_mode === 'co-parenting' && familyCtx.parent_names.length >= 2
+    ? (isPl
+        ? `Rodzice: ${familyCtx.parent_names.join(' i ')}. Zwracaj się do obojga rodziców, gdy to stosowne.`
+        : `Parents: ${familyCtx.parent_names.join(' and ')}. Address both parents when contextually relevant.`)
+    : (isPl
+        ? 'Rodzina z jednym rodzicem. Nie używaj "oboje rodziców" ani nie wspominaj o współrodzicielstwie.'
+        : 'Single-parent family. Never say "both parents" or reference a co-parent.')
+
+  const siblingLine = familyCtx.child_count > 1
+    ? (isPl
+        ? `Rodzina ma ${familyCtx.child_count} dzieci. Możesz świętować sukcesy całej rodziny (np. "Cały Sad kwitnie"), ale NIGDY nie porównuj postępów dzieci.`
+        : `This family has ${familyCtx.child_count} children. You may celebrate whole-family milestones (e.g. "The whole Orchard is thriving"), but NEVER compare children's progress.`)
+    : (isPl
+        ? `${childName} jest jedynym dzieckiem w tej rodzinie.`
+        : `${childName} is the only child in this family.`)
+
+  const nudgeRule = familyCtx.parenting_mode === 'co-parenting' && !familyCtx.has_shield
+    && familyCtx.co_parent_active && (familyCtx.approval_skew ?? 0) > 80
+    ? (isPl
+        ? 'WSKAZÓWKA WSPÓŁPRACY (dozwolona raz w briefingu): Zauważyliśmy, że ostatnio zatwierdzenia pochodzą głównie od jednego rodzica — partner może chcieć bardziej zaangażować się w tym tygodniu. Ton: obserwacja, nie dyrektywa.'
+        : "COLLABORATION NUDGE (allowed once in this briefing): We've noticed most approvals have come from one parent recently — your co-parent might enjoy being more involved this week. Tone: observation, never directive.")
+    : ''
+
+  if (isPl) {
+    return `KONTEKST RODZINNY (obowiązkowy):
+- ${coParentLine}
+- ${siblingLine}
+- Nazwa rodziny: ${familyCtx.family_name}
+- ZAKAZ używania "dzieci" (użyj imienia dziecka lub "Twoje dziecko").
+${nudgeRule}`
+  }
+
+  return `FAMILY CONTEXT (mandatory):
+- ${coParentLine}
+- ${siblingLine}
+- Family name: ${familyCtx.family_name}
+- NEVER say "the kids" — use the child's name or "your child".
+${nudgeRule}`
 }
 
 function buildSystemPrompt(
@@ -484,6 +541,7 @@ function buildSystemPrompt(
   isTeenMode: boolean,
   childName: string,
   honorific: string,
+  familyCtx: FamilyContext,
 ): string {
   const isPl           = locale === 'pl';
   const useFormalPl    = isPl && isTeenMode;
@@ -496,7 +554,10 @@ function buildSystemPrompt(
       ? `FORMALNOŚĆ: Zwracaj się do dziecka per "${formalAddress}" w nudge'u. Ton: formalny, bezpośredni, szanujący autonomię.`
       : `FORMALNOŚĆ: Używaj prostego, ciepłego języka odpowiedniego dla młodszych dzieci. Bez formalnych tytułów.`;
 
-    return `Jesteś "Mistrzem Sadu" (Mistrz Sadu) — wysokiej klasy konsultantem finansowym dla rodziców. \
+    const familyBlock = buildInsightsFamilyBlock(familyCtx, childName, locale)
+    return `${familyBlock}
+
+Jesteś "Mistrzem Sadu" (Mistrz Sadu) — wysokiej klasy konsultantem finansowym dla rodziców. \
 Twoim celem jest analiza danych finansowych dziecka i przygotowanie profesjonalnego raportu opartego na Matrycy Edukacji Finansowej Morechard.
 
 MATRYCA EDUKACJI FINANSOWEJ (obowiązkowy program nauczania):
@@ -535,7 +596,10 @@ Schemat odpowiedzi (ścisły):
   }
 
   // ── English persona: Collaborative Coach (Orchard Lead) ──────────────────
-  return `You are the 'Orchard Lead', a collaborative financial coach for parents. \
+  const familyBlock = buildInsightsFamilyBlock(familyCtx, childName, locale)
+  return `${familyBlock}
+
+You are the 'Orchard Lead', a collaborative financial coach for parents. \
 Your goal is to analyse child financial behaviour data and produce a professional executive briefing grounded in the Morechard Financial Literacy Matrix.
 
 THE LITERACY MATRIX (your mandatory syllabus):
@@ -572,12 +636,55 @@ Response schema (strict):
 }`;
 }
 
+function applyCollaborationNudge(
+  briefing: MentorBriefing,
+  familyCtx: FamilyContext,
+  locale: 'en' | 'pl',
+  isSeedling: boolean,
+): MentorBriefing {
+  const shouldNudge =
+    familyCtx.parenting_mode === 'co-parenting' &&
+    !familyCtx.has_shield &&
+    familyCtx.co_parent_active &&
+    (familyCtx.approval_skew ?? 0) > 80
+
+  if (!shouldNudge) return briefing
+
+  const coParentName = familyCtx.parent_names.length >= 2
+    ? familyCtx.parent_names[1]
+    : (locale === 'pl' ? 'partner' : 'your partner')
+
+  const nudgeSuffix = locale === 'pl'
+    ? ` Zauważyliśmy również, że ostatnio zatwierdzenia pochodzą głównie od jednego rodzica — ${coParentName} może chcieć bardziej zaangażować się w tym tygodniu.`
+    : ` We've also noticed most approvals have come from one parent recently — ${coParentName} might enjoy being more involved this week.`
+
+  return {
+    ...briefing,
+    the_nudge: briefing.the_nudge + nudgeSuffix,
+  }
+}
+
 function buildRuleBasedBriefing(input: BriefingInput): MentorBriefing {
   const {
     trends, consistencyScore, firstTimePassRate, planningHorizon,
     velocityContext, availableBalancePence, goalsLockedPence, locale,
-    childName, honorific,
+    childName, honorific, familyCtx,
   } = input;
+
+  // Co-parent address string
+  const coParentName = familyCtx.parenting_mode === 'co-parenting' && familyCtx.parent_names.length >= 2
+    ? familyCtx.parent_names.filter(n => n !== familyCtx.parent_names[0])[0] ?? 'your partner'
+    : null;
+  const parentAddress = coParentName
+    ? (locale === 'pl' ? `Ty i ${coParentName}` : `you and ${coParentName}`)
+    : (locale === 'pl' ? 'Ty' : 'you');
+
+  // Sibling team line for Pillar 5 (positive-only)
+  const siblingTeamLine = familyCtx.child_count > 1
+    ? (locale === 'pl'
+        ? ` Cały Sad ${familyCtx.family_name} kwitnie w tym tygodniu.`
+        : ` The whole ${familyCtx.family_name} Orchard is thriving this week.`)
+    : '';
 
   const isSeedling      = velocityContext.mode === 'seedling';
   const isPl            = locale === 'pl';
@@ -602,11 +709,11 @@ function buildRuleBasedBriefing(input: BriefingInput): MentorBriefing {
 
     const obs = hasSurplus
       ? (isPl
-          ? `Zauważyliśmy, że dostępne saldo przekroczyło ${balanceDisplay}—w Sadzie zgromadził się znaczący nadmiar.`
-          : `We have noted that the available balance has exceeded ${balanceDisplay}—a meaningful surplus has accumulated in the Orchard.`)
+          ? `Zauważyliśmy, że dostępne saldo przekroczyło ${balanceDisplay}—w Sadzie zgromadził się znaczący nadmiar.${siblingTeamLine}`
+          : `We have noted that the available balance has exceeded ${balanceDisplay}—a meaningful surplus has accumulated in the Orchard.${siblingTeamLine}`)
       : (isPl
-          ? 'Zauważyliśmy, że wszystkie aktywne cele oszczędnościowe zostały w pełni sfinansowane w tym okresie—to ważny kamień milowy w cyklu Zbiorów.'
-          : 'We have observed that all active savings goals have been fully funded this period—a significant milestone in the Harvest cycle.');
+          ? `Zauważyliśmy, że wszystkie aktywne cele oszczędnościowe zostały w pełni sfinansowane w tym okresie—to ważny kamień milowy w cyklu Zbiorów.${siblingTeamLine}`
+          : `We have observed that all active savings goals have been fully funded this period—a significant milestone in the Harvest cycle.${siblingTeamLine}`);
 
     // Polish Pillar 5: "Honor i Obowiązek Zbiorów" framing (cultural duty, not optional charity)
     const root = isPl
@@ -625,7 +732,7 @@ function buildRuleBasedBriefing(input: BriefingInput): MentorBriefing {
           ? `You might consider exploring a small giving goal together—even £1–£2 toward a cause ${childName} cares about introduces the Give grove without disrupting their savings rhythm.`
           : `You might consider introducing a Social Allocation target (e.g., 5–10% of surplus) and discussing with ${childName} what they would fund—this anchors Pillar 5 in a real decision rather than an abstract concept.`);
 
-    return { observation: obs, behavioral_root: root, the_nudge: nudge, source: 'fallback' };
+    return applyCollaborationNudge({ observation: obs, behavioral_root: root, the_nudge: nudge, source: 'fallback' }, familyCtx, locale, isSeedling);
   }
 
   // ── Priority 2: Pillar 3 — Opportunity Cost ───────────────────────────────
@@ -647,7 +754,7 @@ function buildRuleBasedBriefing(input: BriefingInput): MentorBriefing {
       : (isSeedling
           ? `You might consider identifying one thing ${childName} bought recently and asking: "What goal could that have moved forward?"—this is the Pruning conversation in its simplest form.`
           : `You might consider calculating the "Time-to-Goal cost" of ${childName}'s recent discretionary spends—presenting this as a trade-off ratio (e.g., "3 days of velocity") makes the Opportunity Cost tangible.`);
-    return { observation: obs, behavioral_root: root, the_nudge: nudge, source: 'fallback' };
+    return applyCollaborationNudge({ observation: obs, behavioral_root: root, the_nudge: nudge, source: 'fallback' }, familyCtx, locale, isSeedling);
   }
 
   // ── Priority 3: Pillar 1 — Labour Value ──────────────────────────────────
@@ -680,7 +787,7 @@ function buildRuleBasedBriefing(input: BriefingInput): MentorBriefing {
       : (isSeedling
           ? `You might consider restating the task-to-reward equation simply to ${childName}: "Each completed task = one step closer to your goal"—reanchoring the effort-value link visually.`
           : `You might consider introducing a "High-Integrity Streak" bonus for ${childName} for five consecutive first-time passes—framing it as a professional quality metric rather than a reward for compliance.`);
-    return { observation: obs, behavioral_root: root, the_nudge: nudge, source: 'fallback' };
+    return applyCollaborationNudge({ observation: obs, behavioral_root: root, the_nudge: nudge, source: 'fallback' }, familyCtx, locale, isSeedling);
   }
 
   // ── Priority 4: Pillar 2 — Delayed Gratification ─────────────────────────
@@ -702,7 +809,7 @@ function buildRuleBasedBriefing(input: BriefingInput): MentorBriefing {
       : (isSeedling
           ? `You might consider calculating how many tasks remain until ${childName}'s goal is reached and displaying it as a countdown—making the "Season" feel tangible and near.`
           : `You might consider reviewing the Time-to-Goal estimate with ${childName} and discussing whether adjusting the savings allocation rate would meaningfully accelerate the harvest date.`);
-    return { observation: obs, behavioral_root: root, the_nudge: nudge, source: 'fallback' };
+    return applyCollaborationNudge({ observation: obs, behavioral_root: root, the_nudge: nudge, source: 'fallback' }, familyCtx, locale, isSeedling);
   }
 
   // ── Priority 5: Pillar 4 — Capital Management ────────────────────────────
@@ -726,9 +833,9 @@ function buildRuleBasedBriefing(input: BriefingInput): MentorBriefing {
           ? `Możesz rozważyć wprowadzenie idei "Wzmocnienia" jako wkładu dopasowującego rodzica—przedstawiając to ${childName} jako "Sad rosnący z nasienia" czyni procent składany intuicyjnym.`
           : `Możesz rozważyć wspólne modelowanie z ${formalAddr}, jak wyglądałby 5% lub 10% roczny zwrot na obecnym saldzie oszczędności—zakotwicza to Filar 4 w realnej liczbie.`)
       : (isSeedling
-          ? `You might consider introducing the idea of a "Boost" from a parent as a matching contribution—framing it to ${childName} as "the Orchard growing your seed" makes compound interest intuitive.`
-          : `You might consider modelling with ${childName} what a 5% or 10% annual return would look like on their current savings balance—this anchors Pillar 4 in a real number rather than an abstract concept.`);
-    return { observation: obs, behavioral_root: root, the_nudge: nudge, source: 'fallback' };
+          ? `You might consider ${coParentName ? `${parentAddress} introducing` : 'introducing'} the idea of a "Boost" as a matching contribution—framing it to ${childName} as "the Orchard growing your seed" makes compound interest intuitive.`
+          : `You might consider ${coParentName ? `${parentAddress} modelling` : 'modelling'} with ${childName} what a 5% or 10% annual return would look like on their current savings balance—this anchors Pillar 4 in a real number rather than an abstract concept.`);
+    return applyCollaborationNudge({ observation: obs, behavioral_root: root, the_nudge: nudge, source: 'fallback' }, familyCtx, locale, isSeedling);
   }
 
   // ── Default: mixed signals ────────────────────────────────────────────────
@@ -745,12 +852,12 @@ function buildRuleBasedBriefing(input: BriefingInput): MentorBriefing {
     : (isSeedling
         ? `You might consider holding the current structure steady and focusing on ${childName} completing one full week of tasks without revision—building the consistency baseline before introducing new complexity.`
         : `You might consider reviewing ${childName}'s current task portfolio and assessing whether the reward structure is appropriately calibrated to the effort required—misalignment is a common driver of mixed-signal periods.`);
-  return { observation: obs, behavioral_root: root, the_nudge: nudge, source: 'fallback' };
+  return applyCollaborationNudge({ observation: obs, behavioral_root: root, the_nudge: nudge, source: 'fallback' }, familyCtx, locale, isSeedling);
 }
 
 async function generateBriefing(env: Env, childId: string, input: BriefingInput): Promise<MentorBriefing> {
   const isTeenMode   = input.velocityContext.mode === 'professional';
-  const systemPrompt = buildSystemPrompt(input.locale, isTeenMode, input.childName, input.honorific);
+  const systemPrompt = buildSystemPrompt(input.locale, isTeenMode, input.childName, input.honorific, input.familyCtx);
 
   const userMessage = JSON.stringify({
     consistency_score:       input.consistencyScore,

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -50,6 +50,18 @@ export type Currency = 'GBP' | 'PLN' | 'USD';
 export type Locale = 'en' | 'en-US' | 'pl';
 export type VerifyMode = 'amicable' | 'standard';
 export type ParentingMode = 'single' | 'co-parenting';
+
+export interface FamilyContext {
+  parenting_mode:   'single' | 'co-parenting';
+  child_count:      number;
+  child_names:      string[];    // first names of all children
+  parent_names:     string[];    // first names of lead + all co-parents
+  family_name:      string;      // families.name fallback: "the family"
+  co_parent_active: boolean;     // both parents approved ≥1 chore in last 30d
+  approval_skew:    number | null; // % of approvals by most-active parent (last 30d); null when single or <5 approvals
+  has_shield:       boolean;     // Shield plan active — suppresses collaboration nudges
+}
+
 export type InviteRole = 'child' | 'co-parent';
 export type EntryType = 'credit' | 'reversal' | 'payment';
 export type VerificationStatus = 'pending' | 'verified_auto' | 'verified_manual' | 'disputed' | 'reversed';


### PR DESCRIPTION
## Summary

- **New tier structure**: Renames 'Lifetime Tracker' to Complete (£44.99) and introduces Shield (£149.99) as a distinct professional-grade tier with amber visual treatment, a 'Professional' badge, and an amber glow ring to signal it's a specialist tool rather than just a pricier version
- **Benefit-first copy**: Full CTA buttons replace chevron rows; Shield card includes tamper-seal explainer in plain English; all language uses 'professional review' framing — no court admissibility claims
- **Compare Plans modal**: 11-feature grid, Free / Complete / Shield columns, mediation price anchor ('UK family mediation averages £140/hr. Shield is a one-time £149.99.')
- **AI Mentor restructure**: Always visible as 'Optional Family Add-Ons' section at bottom; trial users see 'Available for Complete and Shield members' (invitation framing); paid users get a full CTA button
- **API types**: `createCheckoutSession` and `PaymentRecord.payment_type` extended with `COMPLETE` and `SHIELD`

## Test plan

- [ ] Trial user sees Complete + Shield upgrade cards + AI Mentor teaser with 'Available for Complete and Shield members' note
- [ ] Complete holder sees Shield upgrade card + AI Mentor CTA button
- [ ] Shield holder sees no upgrade cards, only AI Mentor CTA
- [ ] Complete + AI / Shield + AI: no add-on section shown
- [ ] 'Why professionals prefer Shield' link opens Compare Plans modal; tap outside or X closes it
- [ ] All three CTA buttons ('Get Lifetime Access', 'Get Shield Protection', 'Add AI Mentor') trigger checkout flow; loading state shown while awaiting redirect
- [ ] Payment History labels correctly display COMPLETE and SHIELD payment types

🤖 Generated with [Claude Code](https://claude.com/claude-code)