### PR TITLE
feat(auth): staged email verification via Resend + UI polish

### DIFF
--- a/app/src/components/dashboard/ParentSettingsTab.tsx
+++ b/app/src/components/dashboard/ParentSettingsTab.tsx
@@ -180,6 +180,17 @@ export function ParentSettingsTab({ familyId, online, onChildrenChange, onClose 
 
   const { toast, showToast } = useToast()
 
+  // Show toast + clean URL if redirected back from email verification link
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    if (params.get('emailVerified') === '1') {
+      showToast('Email address confirmed — your new address is now active')
+      const clean = window.location.pathname
+      window.history.replaceState({}, '', clean)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   // Profile (loaded from GET /auth/me)
   const [profile,   setProfile]   = useState<MeResult | null>(null)
   const [leadCount, setLeadCount] = useState<number>(1)

--- a/app/src/components/settings/sections/BillingSettings.tsx
+++ b/app/src/components/settings/sections/BillingSettings.tsx
@@ -387,7 +387,7 @@ function PlanView({ onBack, showToast, shieldUpgradePrice }: {
                   <button
                     type="button"
                     onClick={() => setShowCompare(true)}
-                    className="text-[12px] font-semibold text-[var(--brand-primary)] hover:opacity-75 transition-opacity"
+                    className="text-[12px] font-semibold text-[var(--brand-primary)] px-2.5 py-1 rounded-lg border border-[var(--brand-primary)] hover:bg-[color-mix(in_srgb,var(--brand-primary)_10%,transparent)] active:bg-[color-mix(in_srgb,var(--brand-primary)_18%,transparent)] active:scale-[0.97] transition-all duration-150"
                   >
                     Compare all plans
                   </button>
@@ -556,7 +556,7 @@ function PlanView({ onBack, showToast, shieldUpgradePrice }: {
                       type="button"
                       disabled={buying !== null}
                       onClick={() => handlePurchase('SHIELD_AI')}
-                      className="w-full py-2.5 rounded-xl bg-amber-500 text-white text-[13px] font-bold hover:opacity-90 active:opacity-80 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+                      className="w-full py-2.5 rounded-xl bg-amber-500 text-white text-[13px] font-bold hover:bg-amber-600 hover:shadow-[0_4px_14px_color-mix(in_srgb,#f59e0b_40%,transparent)] active:bg-amber-700 active:scale-[0.98] active:shadow-none transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       {buying === 'SHIELD_AI'
                         ? 'Loading…'
@@ -587,7 +587,7 @@ function PlanView({ onBack, showToast, shieldUpgradePrice }: {
                     <button
                       type="button"
                       onClick={() => setShowCancelConfirm(true)}
-                      className="text-[12px] font-semibold text-red-500 hover:text-red-600 transition-colors"
+                      className="text-[12px] font-semibold text-red-500 px-2.5 py-1 rounded-lg border border-red-300 hover:bg-red-50 hover:text-red-600 hover:border-red-400 active:bg-red-100 active:scale-[0.97] transition-all duration-150"
                     >
                       Cancel plan & request refund
                     </button>

--- a/app/src/components/settings/sections/ProfileSettings.tsx
+++ b/app/src/components/settings/sections/ProfileSettings.tsx
@@ -52,10 +52,11 @@ export function ProfileSettings({
   const [nameError,   setNameError]   = useState<string | null>(null)
 
   // Email inline edit
-  const [editingEmail, setEditingEmail] = useState(false)
-  const [emailInput,   setEmailInput]   = useState('')
-  const [emailSaving,  setEmailSaving]  = useState(false)
-  const [emailError,   setEmailError]   = useState<string | null>(null)
+  const [editingEmail,    setEditingEmail]    = useState(false)
+  const [emailInput,      setEmailInput]      = useState('')
+  const [emailSaving,     setEmailSaving]     = useState(false)
+  const [emailError,      setEmailError]      = useState<string | null>(null)
+  const [emailSentTo,     setEmailSentTo]     = useState<string | null>(null)
 
   // Danger zone modal state
   const [showLeaveModal,  setShowLeaveModal]  = useState(false)
@@ -89,6 +90,7 @@ export function ProfileSettings({
     try {
       await onSaveEmail(trimmed)
       setEditingEmail(false)
+      setEmailSentTo(trimmed)
     } catch (err: unknown) {
       setEmailError((err as Error).message)
     } finally {
@@ -147,32 +149,45 @@ export function ProfileSettings({
       {/* Avatar */}
       <SectionCard>
         <div className="px-4 py-3.5 flex items-center gap-3">
-          <button
-            onClick={() => setShowAvatarPicker(true)}
-            className="relative cursor-pointer group shrink-0"
-            title="Change avatar"
-          >
-            {myAvatar
-              ? <AvatarSVG id={myAvatar} size={52} />
-              : <DefaultAvatar size={52} initials={identity?.initials ?? identity?.display_name ?? 'P'} />
-            }
-            <span className="absolute inset-0 flex items-center justify-center bg-black/0 group-hover:bg-black/20 rounded-full transition-colors text-white text-[18px] opacity-0 group-hover:opacity-100">✎</span>
-          </button>
+          {identity?.google_picture ? (
+            <img
+              src={identity.google_picture}
+              alt={identity.display_name}
+              className="w-[52px] h-[52px] rounded-full object-cover border-2 border-[var(--brand-primary)] shrink-0"
+              onError={e => { (e.target as HTMLImageElement).style.display = 'none' }}
+            />
+          ) : (
+            <button
+              onClick={() => setShowAvatarPicker(true)}
+              className="relative cursor-pointer group shrink-0"
+              title="Change avatar"
+            >
+              {myAvatar
+                ? <AvatarSVG id={myAvatar} size={52} />
+                : <DefaultAvatar size={52} initials={identity?.initials ?? identity?.display_name ?? 'P'} />
+              }
+              <span className="absolute inset-0 flex items-center justify-center bg-black/0 group-hover:bg-black/20 rounded-full transition-colors text-white text-[18px] opacity-0 group-hover:opacity-100">✎</span>
+            </button>
+          )}
           <div>
             <p className="text-[14px] font-semibold text-[var(--color-text)]">
               {(family.display_name as string) ?? identity?.display_name ?? 'My family'}
             </p>
-            <button
-              onClick={() => setShowAvatarPicker(true)}
-              className="text-[12px] font-semibold text-[var(--brand-primary)] hover:underline cursor-pointer"
-            >
-              Change avatar
-            </button>
+            {identity?.google_picture ? (
+              <p className="text-[12px] text-[var(--color-text-muted)]">Google profile picture</p>
+            ) : (
+              <button
+                onClick={() => setShowAvatarPicker(true)}
+                className="text-[12px] font-semibold text-[var(--brand-primary)] hover:underline cursor-pointer"
+              >
+                Change avatar
+              </button>
+            )}
           </div>
         </div>
       </SectionCard>
 
-      {showAvatarPicker && (
+      {!identity?.google_picture && showAvatarPicker && (
         <SectionCard>
           <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--color-border)]">
             <p className="text-[15px] font-bold">Choose avatar</p>
@@ -251,16 +266,30 @@ export function ProfileSettings({
         <SettingsRow
           icon={<Shield size={15} />}
           label="Email"
-          description={profile?.email ?? 'No email set'}
-          badge={profile && (profile.email_verified === 0 || profile.email_pending) ? 'Unverified' : undefined}
+          description={profile?.email_pending
+            ? `${profile.email} · change pending`
+            : (profile?.email ?? 'No email set')}
+          badge={profile?.email_pending
+            ? 'Verify pending'
+            : (profile && profile.email_verified === 0 ? 'Unverified' : undefined)}
           onClick={() => {
             setEmailInput(profile?.email ?? '')
             setEmailError(null)
+            setEmailSentTo(null)
             setEditingEmail(v => !v)
             setEditingName(false)
             setShowAvatarPicker(false)
           }}
         />
+        {emailSentTo && !editingEmail && (
+          <div className="px-4 py-3 border-t border-[var(--color-border)] flex items-start gap-2 bg-teal-50">
+            <span className="text-teal-600 shrink-0 mt-0.5">✓</span>
+            <p className="text-[12px] text-teal-700 leading-snug">
+              Verification email sent to <span className="font-semibold">{emailSentTo}</span>. Click the link in that email to confirm the change — your current address remains active until then.
+            </p>
+          </div>
+        )}
+
         {editingEmail && (
           <form onSubmit={handleSaveEmail} className="px-4 py-3 border-t border-[var(--color-border)] space-y-2">
             <input

--- a/worker/migrations/0055_email_verify_tokens.sql
+++ b/worker/migrations/0055_email_verify_tokens.sql
@@ -1,0 +1,17 @@
+-- Migration 0055: email_verify_tokens
+--
+-- Stores short-lived tokens used to confirm a new email address
+-- before it replaces the existing one. Each row is single-use and
+-- expires after 24 hours.
+
+CREATE TABLE IF NOT EXISTS email_verify_tokens (
+  id         INTEGER  PRIMARY KEY AUTOINCREMENT,
+  user_id    TEXT     NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  token      TEXT     NOT NULL UNIQUE,
+  new_email  TEXT     NOT NULL,
+  expires_at INTEGER  NOT NULL,  -- unix timestamp
+  used_at    INTEGER             -- set on consumption; NULL = unused
+);
+
+CREATE INDEX IF NOT EXISTS idx_evt_token   ON email_verify_tokens (token);
+CREATE INDEX IF NOT EXISTS idx_evt_user_id ON email_verify_tokens (user_id);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -126,6 +126,7 @@ import {
   handleLogout,
   handleMe,
   handleMePatch,
+  handleVerifyEmail,
   handleFamilyLeads,
   handleLeaveFamily,
   handleDeleteFamily,
@@ -395,9 +396,10 @@ async function route(request: Request, env: Env, method: string, path: string): 
   if (path === '/auth/demo/notify' && method === 'POST') return withAuth(request, auth, env, handleDemoNotify);
   if (path === '/auth/demo/active' && method === 'GET')  return withAuth(request, auth, env, handleDemoActive);
 
-  if (path === '/auth/me'     && method === 'GET')  return withAuth(request, auth, env, handleMe);
-  if (path === '/auth/me'     && method === 'PATCH') return withAuth(request, auth, env, handleMePatch);
-  if (path === '/auth/logout' && method === 'POST') return withAuth(request, auth, env, handleLogout);
+  if (path === '/auth/me'           && method === 'GET')  return withAuth(request, auth, env, handleMe);
+  if (path === '/auth/me'           && method === 'PATCH') return withAuth(request, auth, env, handleMePatch);
+  if (path === '/auth/verify-email' && method === 'GET')  return handleVerifyEmail(request, env);
+  if (path === '/auth/logout'       && method === 'POST') return withAuth(request, auth, env, handleLogout);
 
   // Co-parent-aware account deletion — placed before trial check so expired-trial users can still delete
   if (path === '/auth/family/leads' && method === 'GET')    return withAuth(request, auth, env, handleFamilyLeads);

--- a/worker/src/lib/email.ts
+++ b/worker/src/lib/email.ts
@@ -16,8 +16,12 @@ export class EmailNotConfiguredError extends Error {
   constructor() { super('Email provider not configured') }
 }
 
+const FROM_ADDRESS = 'Morechard <hello@morechard.com>'
+
 export class EmailService {
   constructor(private env: Env) {}
+
+  // ── Marketing / logged sends ─────────────────────────────────────────────────
 
   async sendEmail(
     to: string,
@@ -35,6 +39,43 @@ export class EmailService {
       await this.updateSendStatus(sendId, 'failed')
     }
   }
+
+  // ── Transactional sends (not logged to email_sends) ──────────────────────────
+
+  async sendTransactional(opts: {
+    to:      string
+    subject: string
+    html:    string
+    text:    string
+  }): Promise<void> {
+    if (this.env.ENVIRONMENT === 'development') {
+      console.log('[EmailService] transactional stub', opts)
+      return
+    }
+    if (!this.env.RESEND_API_KEY) throw new EmailNotConfiguredError()
+
+    const res = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${this.env.RESEND_API_KEY}`,
+        'Content-Type':  'application/json',
+      },
+      body: JSON.stringify({
+        from:    FROM_ADDRESS,
+        to:      [opts.to],
+        subject: opts.subject,
+        html:    opts.html,
+        text:    opts.text,
+      }),
+    })
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => '')
+      throw new Error(`Resend error ${res.status}: ${body}`)
+    }
+  }
+
+  // ── Private helpers ──────────────────────────────────────────────────────────
 
   private async dispatchEmail(
     to: string,
@@ -69,4 +110,62 @@ export class EmailService {
       .bind(status, providerMessageId ?? null, status, id)
       .run()
   }
+}
+
+// ── Email builders ─────────────────────────────────────────────────────────────
+
+export function buildVerifyEmailHtml(verifyUrl: string, displayName: string): string {
+  return `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;background:#f5f5f0;font-family:system-ui,sans-serif">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f5f5f0;padding:40px 16px">
+    <tr><td align="center">
+      <table width="100%" style="max-width:480px;background:#ffffff;border-radius:16px;overflow:hidden;box-shadow:0 2px 8px rgba(0,0,0,0.08)">
+        <tr>
+          <td style="background:#0f6b4f;padding:24px 32px">
+            <p style="margin:0;font-size:20px;font-weight:700;color:#ffffff">🌱 Morechard</p>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:32px">
+            <p style="margin:0 0 8px;font-size:18px;font-weight:700;color:#1a1a1a">Confirm your new email address</p>
+            <p style="margin:0 0 24px;font-size:14px;color:#666;line-height:1.6">
+              Hi ${displayName}, click the button below to confirm this address. The link expires in 24 hours.
+              If you didn't request this change, you can ignore this email — your current address remains active.
+            </p>
+            <a href="${verifyUrl}"
+               style="display:inline-block;background:#0f6b4f;color:#ffffff;font-size:14px;font-weight:700;text-decoration:none;padding:14px 28px;border-radius:10px">
+              Confirm email address
+            </a>
+            <p style="margin:24px 0 0;font-size:12px;color:#999;line-height:1.5">
+              Or copy this link into your browser:<br>
+              <span style="color:#0f6b4f;word-break:break-all">${verifyUrl}</span>
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:16px 32px 24px;border-top:1px solid #f0f0f0">
+            <p style="margin:0;font-size:11px;color:#aaa">
+              Morechard — family finance tracker. All plans are one-time purchases.
+            </p>
+          </td>
+        </tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`
+}
+
+export function buildVerifyEmailText(verifyUrl: string, displayName: string): string {
+  return `Hi ${displayName},
+
+Confirm your new Morechard email address by visiting:
+
+${verifyUrl}
+
+This link expires in 24 hours. If you didn't request this change, ignore this email — your current address stays active.
+
+— Morechard`
 }

--- a/worker/src/routes/auth.ts
+++ b/worker/src/routes/auth.ts
@@ -11,7 +11,8 @@
  * GET  /auth/me                Return current user from JWT
  */
 
-import { Env } from '../types.js';
+import { Env } from '../types.js'
+import { EmailService, buildVerifyEmailHtml, buildVerifyEmailText } from '../lib/email.js';
 import { json, error, clientIp } from '../lib/response.js';
 import { hashPassword, verifyPassword } from '../lib/crypto.js';
 import { signJwt } from '../lib/jwt.js';
@@ -507,14 +508,16 @@ export async function handleMePatch(request: Request, env: Env): Promise<Respons
     await writeSystemNote(`🌱 ${trimmed} updated their family name`);
   }
 
-  // ── Email update ─────────────────────────────────────────────
+  // ── Email update — staged via email_pending; confirmed by verify link ────────
   if (email !== undefined) {
     const trimmedEmail = email.trim().toLowerCase();
-    // Basic RFC-ish format check
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedEmail)) {
       return error('Please enter a valid email address', 400);
     }
-    // Uniqueness check — reject if another verified account has this address
+    if (trimmedEmail === user.email) {
+      return error('That is already your current email address', 400);
+    }
+    // Reject if another verified account already holds this address
     const conflict = await env.DB
       .prepare('SELECT id FROM users WHERE email = ? AND email_verified = 1 AND id != ?')
       .bind(trimmedEmail, caller.sub)
@@ -522,11 +525,44 @@ export async function handleMePatch(request: Request, env: Env): Promise<Respons
     if (conflict) {
       return error('That email address is already registered', 409);
     }
+
+    // Stage the new address and issue a verification token
+    const token      = crypto.randomUUID();
+    const expiresAt  = Math.floor(Date.now() / 1000) + 24 * 60 * 60; // 24 h
+
+    // Invalidate any prior unused tokens for this user
     await env.DB
-      .prepare('UPDATE users SET email = ?, email_verified = 0 WHERE id = ?')
+      .prepare('DELETE FROM email_verify_tokens WHERE user_id = ? AND used_at IS NULL')
+      .bind(caller.sub)
+      .run();
+
+    await env.DB
+      .prepare('INSERT INTO email_verify_tokens (user_id, token, new_email, expires_at) VALUES (?,?,?,?)')
+      .bind(caller.sub, token, trimmedEmail, expiresAt)
+      .run();
+
+    await env.DB
+      .prepare('UPDATE users SET email_pending = ? WHERE id = ?')
       .bind(trimmedEmail, caller.sub)
       .run();
-    await writeSystemNote('🌱 Contact email was updated');
+
+    const verifyUrl = `${env.APP_URL}/auth/verify-email?token=${token}`;
+    try {
+      await new EmailService(env).sendTransactional({
+        to:      trimmedEmail,
+        subject: 'Confirm your new Morechard email address',
+        html:    buildVerifyEmailHtml(verifyUrl, user.display_name),
+        text:    buildVerifyEmailText(verifyUrl, user.display_name),
+      });
+    } catch (err) {
+      console.error('[handleMePatch] verify email send failed', err);
+      // Roll back staging so the user can try again
+      await env.DB.prepare('UPDATE users SET email_pending = NULL WHERE id = ?').bind(caller.sub).run();
+      await env.DB.prepare('DELETE FROM email_verify_tokens WHERE token = ?').bind(token).run();
+      return error('Could not send verification email — please try again', 502);
+    }
+
+    await writeSystemNote('🌱 Email change requested — awaiting verification');
   }
 
   // Return updated profile
@@ -537,6 +573,45 @@ export async function handleMePatch(request: Request, env: Env): Promise<Respons
   if (!updated) return error('User not found', 404);
 
   return json({ ...updated, family_id: caller.family_id, role: caller.role });
+}
+
+// ----------------------------------------------------------------
+// GET /auth/verify-email?token=...
+// Confirms a pending email change. No auth required — token is the credential.
+// On success redirects the user to /parent/settings?emailVerified=1.
+// ----------------------------------------------------------------
+export async function handleVerifyEmail(request: Request, env: Env): Promise<Response> {
+  const url   = new URL(request.url);
+  const token = url.searchParams.get('token');
+
+  if (!token) {
+    return new Response('Missing token', { status: 400 });
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+
+  const row = await env.DB
+    .prepare('SELECT id, user_id, new_email, expires_at, used_at FROM email_verify_tokens WHERE token = ?')
+    .bind(token)
+    .first<{ id: number; user_id: string; new_email: string; expires_at: number; used_at: number | null }>();
+
+  if (!row)          return new Response('Invalid or expired link', { status: 400 });
+  if (row.used_at)   return new Response('This link has already been used', { status: 400 });
+  if (row.expires_at < now) return new Response('This link has expired — please request a new one from Account & Profile settings', { status: 400 });
+
+  // Apply the change: promote email_pending → email, mark verified, clear pending
+  await env.DB
+    .prepare('UPDATE users SET email = ?, email_verified = 1, email_pending = NULL WHERE id = ?')
+    .bind(row.new_email, row.user_id)
+    .run();
+
+  // Mark token as used
+  await env.DB
+    .prepare('UPDATE email_verify_tokens SET used_at = ? WHERE id = ?')
+    .bind(now, row.id)
+    .run();
+
+  return Response.redirect(`${env.APP_URL}/parent/settings?emailVerified=1`, 302);
 }
 
 // ----------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Email verification flow**: changing email now stages to `email_pending` and sends a 24h Resend verification link — old address stays active until confirmed, preventing lockout from typos
- **New D1 migration** (`0055_email_verify_tokens`): single-use token table with expiry and cascade delete
- **New endpoint** `GET /auth/verify-email?token=...`: promotes `email_pending → email`, marks verified, redirects to `/parent/settings?emailVerified=1` with toast confirmation
- **`EmailService`**: wired Resend API into new `sendTransactional()` method; marketing `sendEmail()` unchanged
- **ProfileSettings UI**: shows "Verify pending" badge and inline "check your inbox" banner; Google users see their profile pic + label instead of avatar picker
- **BillingSettings UI**: richer hover/active states on Shield upgrade button, Compare plans button, and Cancel plan link (all now proper button shapes)

## Test plan

- [ ] Change email → verify "Verify pending" badge and inline banner appear
- [ ] Click link in email → redirected to settings with "Email address confirmed" toast; new address is live
- [ ] Expired/used token → appropriate error message shown
- [ ] Google login → avatar section shows profile pic, no "Change avatar" link, picker blocked
- [ ] Shield upgrade button hover → darkens + amber glow shadow; active → scale down
- [ ] Compare all plans → bordered pill button with brand tint on hover
- [ ] Cancel plan → red bordered pill with red-50 fill on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)