### PR TITLE
fix(marketing): reposition Learning Lab tab indicator on resize

### DIFF
--- a/marketing/src/index.html
+++ b/marketing/src/index.html
@@ -853,6 +853,12 @@
     tabs.forEach((tab, i) => tab.addEventListener('click', () => activateTab(i)));
     requestAnimationFrame(() => positionIndicator(tabs[0]));
 
+    const ro = new ResizeObserver(() => {
+      const active = tabs.find(t => t.classList.contains('active')) || tabs[0];
+      positionIndicator(active);
+    });
+    ro.observe(document.getElementById('ll-tabs'));
+
     /* ── Pillar accordion ── */
     const pillars = Array.from(document.querySelectorAll('.ll-pillar'));
     const drawer  = document.getElementById('ll-pillar-drawer');


### PR DESCRIPTION
## Summary
- Adds a `ResizeObserver` on the `#ll-tabs` container so the white highlight bubble repositions whenever the container's size changes
- Fixes the bug where the indicator pill overflows outside the active tab at certain browser widths (caused by flex reflow on resize with no corresponding JS recalculation)

## Test plan
- [ ] Resize the browser window across the Learning Lab tab section on the homepage — highlight bubble should stay snapped to the active tab at all widths
- [ ] Click each tab at narrow and wide viewports to confirm the indicator animates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)