### PR TITLE
fix: redirect moneysteps.pages.dev to app.morechard.com

### DIFF
--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -1,0 +1,10 @@
+export const onRequest: PagesFunction = async (context) => {
+  const url = new URL(context.request.url);
+  if (url.hostname === 'moneysteps.pages.dev') {
+    return Response.redirect(
+      'https://app.morechard.com' + url.pathname + url.search,
+      301
+    );
+  }
+  return context.next();
+};


### PR DESCRIPTION
## Summary

- Adds `functions/_middleware.ts` — a Cloudflare Pages Function that runs on every request
- Any traffic hitting `moneysteps.pages.dev` is 301-redirected to the equivalent path on `app.morechard.com`
- Prevents the raw Pages URL from being publicly accessible (spotted via PostHog traffic)

## Test plan

- [ ] After deploy, visit `https://moneysteps.pages.dev` — should redirect to `https://app.morechard.com`
- [ ] Confirm `app.morechard.com` itself is unaffected
- [ ] Remove the Cloudflare Access application created for `moneysteps.pages.dev` (no longer needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)