### PR TITLE
fix(blog): add heroImage to expensive school trips post

### DIFF
--- a/marketing/blog/expensive-school-trips.md
+++ b/marketing/blog/expensive-school-trips.md
@@ -5,6 +5,8 @@ type: post
 pillar: effort-reward-connection
 description: "A letter from school offered my son a £3,000 trip to China. Before we say yes, he has to show us how much he wants it. Here's the thinking - and the research."
 author: Darren Savery
+heroImage: expensive-school-trips-part-1
+draft: false
 datePublished: 2026-06-11
 dateModified: 2026-06-11
 schemaType: BlogPosting


### PR DESCRIPTION
## Summary
- Adds missing `heroImage: expensive-school-trips-part-1` frontmatter field
- Adds `draft: false` to match other published posts
- Image file is already in the repo at `marketing/src/Images/expensive-school-trips-part-1.webp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)