### PR TITLE
Family Audit: monthly family-wide AI rollup + EU AI Act disclosure standardization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,7 +230,7 @@ cd worker && npx wrangler d1 migrations apply morechard --remote --env productio
   - [x] `insight_snapshots` D1 table — weekly KPI snapshots with trend deltas (consistency, responsibility, planning horizon)
   - [x] Temporal context: delta calculation vs. prior week snapshot, direction indicators (up/down/flat)
   - [x] Velocity context: Orchard mode (avg tasks/week) vs. Clean mode (avg £ earned/week)
-  - [x] Orchard Lead AI briefing via `@cf/meta/llama-3-8b-instruct` with 5s timeout + rule-based fallback
+  - [x] Orchard Lead AI briefing via OpenAI `gpt-4o-mini` with 10s timeout + rule-based fallback
   - [x] D1 briefing cache — AI runs once per week per child; subsequent loads return instantly
   - [x] Literacy Matrix integration — all briefings grounded in Pillars 1–5 with explicit Pillar naming
   - [x] Pillar 5 surplus trigger — fires when balance > £100 or all goals funded

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,8 +245,7 @@ cd worker && npx wrangler d1 migrations apply morechard --remote --env productio
   - [x] CreateChoreSheet tile grid + fuzzy search redesign
   - [x] RateGuideSheet (parent) + ChoreGuideSheet (child)
   - [x] Fast-Track suggestion flow (post-save prompt)
-- [ ] An AI-driven "Audit" of monthly spending across all children to identify family-wide trends
-- [ ] Linking "Seasonal" events (Birthdays, Holidays, School trips) to the Mentor's advice so it can predict future spending needs
+- [x] An AI-driven "Audit" of monthly spending across all children to identify family-wide trends — Family Audit card in parent Insights tab (`GET /api/family-audit`, `family_audit_snapshots` cache table); shares the "Orchard Mentor" header/`ProBadge`/`AiDisclosurePill` design system with the per-child briefing card
 
 ### **Phase 6: Compliance & Legal (The "Audit" Factor)**
 - [ ] Build 'Court-Ready' PDF Audit Export for co-parents

--- a/app/src/components/child/ChildNudgeBanner.tsx
+++ b/app/src/components/child/ChildNudgeBanner.tsx
@@ -12,7 +12,7 @@
  */
 
 import { useEffect } from 'react'
-import { injectPremiumStyles, PremiumShell, MentorAvatar } from '../ui/PremiumShell'
+import { injectPremiumStyles, PremiumShell, MentorAvatar, AiDisclosurePill } from '../ui/PremiumShell'
 import { dismissChildNudge } from '../../lib/api'
 import type { ChildNudge } from '../../lib/api'
 
@@ -55,9 +55,12 @@ export function ChildNudgeBanner({ nudge, appView, onDismiss }: Props) {
         <div className="flex items-start gap-3 mb-3">
           <MentorAvatar accent={accent} />
           <div className="flex-1 min-w-0">
-            <p className="text-[10px] font-black uppercase tracking-wider" style={{ color: accent }}>
-              Your Orchard Mentor
-            </p>
+            <div className="flex items-center gap-1.5">
+              <p className="text-[10px] font-black uppercase tracking-wider" style={{ color: accent }}>
+                Your Orchard Mentor
+              </p>
+              {nudge.source === 'ai' && <AiDisclosurePill />}
+            </div>
             <p className="text-[11px] mt-0.5" style={{ color: 'rgba(167,196,181,0.7)' }}>
               {pillarLabel}
             </p>
@@ -80,9 +83,9 @@ export function ChildNudgeBanner({ nudge, appView, onDismiss }: Props) {
           {text}
         </p>
 
-        {/* Attribution footer */}
+        {/* Attribution footer — the AI-generated distinction is now carried by the header pill above */}
         <p className="text-[10px] mt-3 text-center" style={{ color: 'rgba(107,158,135,0.6)' }}>
-          ✦ Your Orchard Mentor · {nudge.source === 'ai' ? 'AI coaching note' : 'Personalised coaching'}
+          ✦ Your Orchard Mentor · Personalised coaching
         </p>
 
       </div>

--- a/app/src/components/child/__tests__/ChildNudgeBanner.test.tsx
+++ b/app/src/components/child/__tests__/ChildNudgeBanner.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { ChildNudgeBanner } from '../ChildNudgeBanner'
+import type { ChildNudge } from '../../../lib/api'
+
+function makeNudge(source: ChildNudge['source']): ChildNudge {
+  return {
+    id: 1,
+    trigger_type: 'streak_3',
+    screen_context: 'earn',
+    orchard_text: 'Three tasks in a row!',
+    clean_text: 'Three-day streak.',
+    pillar: 'LABOR_VALUE',
+    tone: 'encouraging',
+    source,
+    parent_summary: 'Streak nudge',
+    created_at: 0,
+  }
+}
+
+describe('ChildNudgeBanner', () => {
+  it('shows the AI-generated pill when source is ai', () => {
+    render(<ChildNudgeBanner nudge={makeNudge('ai')} appView="ORCHARD" onDismiss={vi.fn()} />)
+    expect(screen.getByText('AI-generated')).toBeTruthy()
+  })
+
+  it('does not show the pill for rule_based nudges', () => {
+    render(<ChildNudgeBanner nudge={makeNudge('rule_based')} appView="ORCHARD" onDismiss={vi.fn()} />)
+    expect(screen.queryByText('AI-generated')).toBeNull()
+  })
+
+  it('still renders a static attribution footer regardless of source', () => {
+    render(<ChildNudgeBanner nudge={makeNudge('rule_based')} appView="ORCHARD" onDismiss={vi.fn()} />)
+    expect(screen.getByText(/Personalised coaching/)).toBeTruthy()
+  })
+})

--- a/app/src/components/dashboard/FamilyAuditCard.tsx
+++ b/app/src/components/dashboard/FamilyAuditCard.tsx
@@ -7,7 +7,7 @@
 import { useEffect, useState } from 'react'
 import { getFamilyAudit } from '../../lib/api'
 import type { FamilyAuditData } from '../../lib/api'
-import { PremiumShell, MentorAvatar, AiDisclosurePill, injectPremiumStyles } from '../ui/PremiumShell'
+import { PremiumShell, MentorAvatar, ProBadge, AiDisclosurePill, injectPremiumStyles } from '../ui/PremiumShell'
 
 interface Props {
   familyId: string
@@ -46,12 +46,23 @@ export function FamilyAuditCard({ familyId }: Props) {
     <PremiumShell>
       <div className="px-4 pt-4 pb-3.5 relative z-10">
 
-        <div className="flex items-center gap-2 mb-3">
-          <MentorAvatar />
-          <span className="text-[10px] font-black uppercase tracking-wider" style={{ color: '#0d9488' }}>
-            This Month, Family-Wide
-          </span>
-          {data.source === 'ai' && <AiDisclosurePill />}
+        {/* Header row — matches DiscoveryCard / LiveBriefingCard exactly */}
+        <div className="flex items-start justify-between gap-3 mb-3">
+          <div className="flex items-center gap-3">
+            <MentorAvatar />
+            <div>
+              <div className="flex items-center gap-2 mb-0.5">
+                <span className="text-[10px] font-bold tracking-widest uppercase" style={{ color: '#6b9e87' }}>
+                  Orchard Mentor
+                </span>
+                {data.source === 'ai' && <AiDisclosurePill />}
+              </div>
+              <p className="text-[15px] font-extrabold tracking-tight" style={{ color: '#f0fdf4' }}>
+                This Month, Family-Wide
+              </p>
+            </div>
+          </div>
+          <ProBadge />
         </div>
 
         <div className="grid grid-cols-4 gap-2 mb-3.5">

--- a/app/src/components/dashboard/FamilyAuditCard.tsx
+++ b/app/src/components/dashboard/FamilyAuditCard.tsx
@@ -1,0 +1,79 @@
+// app/src/components/dashboard/FamilyAuditCard.tsx
+//
+// Monthly, family-wide AI rollup card — sits above the per-child Insights
+// dashboard. Fetched once per InsightsTab mount (family-scoped, not
+// re-fetched when the parent switches the selected child).
+
+import { useEffect, useState } from 'react'
+import { getFamilyAudit } from '../../lib/api'
+import type { FamilyAuditData } from '../../lib/api'
+import { PremiumShell, MentorAvatar, AiDisclosurePill, injectPremiumStyles } from '../ui/PremiumShell'
+
+interface Props {
+  familyId: string
+}
+
+const STAT_LABELS = [
+  { key: 'total_earned_pence', label: 'Earned' },
+  { key: 'total_spent_pence',  label: 'Spent'  },
+  { key: 'total_saved_pence',  label: 'Saved'  },
+  { key: 'total_given_pence',  label: 'Given'  },
+] as const
+
+function formatPence(pence: number): string {
+  return `£${(pence / 100).toFixed(2)}`
+}
+
+export function FamilyAuditCard({ familyId }: Props) {
+  const [data, setData]       = useState<FamilyAuditData | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => { injectPremiumStyles() }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    getFamilyAudit(familyId)
+      .then(d => { if (!cancelled) setData(d) })
+      .catch(() => { if (!cancelled) setData(null) })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [familyId])
+
+  if (loading || !data || data.is_empty || !data.totals) return null
+
+  return (
+    <PremiumShell>
+      <div className="px-4 pt-4 pb-3.5 relative z-10">
+
+        <div className="flex items-center gap-2 mb-3">
+          <MentorAvatar />
+          <span className="text-[10px] font-black uppercase tracking-wider" style={{ color: '#0d9488' }}>
+            This Month, Family-Wide
+          </span>
+          {data.source === 'ai' && <AiDisclosurePill />}
+        </div>
+
+        <div className="grid grid-cols-4 gap-2 mb-3.5">
+          {STAT_LABELS.map(({ key, label }) => (
+            <div key={key} className="text-center">
+              <p className="text-[13px] font-extrabold tabular-nums" style={{ color: '#f0fdf4' }}>
+                {formatPence(data.totals![key])}
+              </p>
+              <p className="text-[9px] uppercase tracking-wide" style={{ color: 'rgba(167,196,181,0.6)' }}>
+                {label}
+              </p>
+            </div>
+          ))}
+        </div>
+
+        <div className="space-y-1.5">
+          <p className="text-[13px] leading-relaxed" style={{ color: '#e2f5ee' }}>{data.observation}</p>
+          <p className="text-[12px] leading-relaxed" style={{ color: '#a7c4b5' }}>{data.behavioral_root}</p>
+          <p className="text-[12px] leading-relaxed font-semibold" style={{ color: '#6b9e87' }}>{data.the_action}</p>
+        </div>
+
+      </div>
+    </PremiumShell>
+  )
+}

--- a/app/src/components/dashboard/InsightsTab.tsx
+++ b/app/src/components/dashboard/InsightsTab.tsx
@@ -17,7 +17,7 @@ import { AnimatePresence } from 'framer-motion'
 import type { ChildRecord, InsightsData, MentorBriefing } from '../../lib/api'
 import { getInsights, formatCurrency, getChildNudges } from '../../lib/api'
 import { useAndroidBack } from '../../hooks/useAndroidBack'
-import { PremiumShell, MentorAvatar, ProBadge, injectPremiumStyles } from '../ui/PremiumShell'
+import { PremiumShell, MentorAvatar, ProBadge, AiDisclosurePill, injectPremiumStyles } from '../ui/PremiumShell'
 import { SparklineCard } from './SparklineCard'
 import { SparklineExpanded } from './SparklineExpanded'
 import { LabSection } from './LabSection'
@@ -538,12 +538,7 @@ function LiveBriefingCard({
                     {p.label}
                   </span>
                   {/* EU AI Act Article 50 disclosure — visible on every AI-generated card */}
-                  {briefing.source !== 'fallback' && (
-                    <span className="text-[9px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded-full"
-                          style={{ background: 'rgba(255,255,255,0.08)', color: 'rgba(164,196,181,0.85)', border: '1px solid rgba(255,255,255,0.1)' }}>
-                      AI-generated
-                    </span>
-                  )}
+                  {briefing.source !== 'fallback' && <AiDisclosurePill />}
                 </div>
                 <p className="text-[15px] font-extrabold tracking-tight" style={{ color: '#f0fdf4' }}>
                   {PERIOD_NOTE_LABEL[period]}

--- a/app/src/components/dashboard/InsightsTab.tsx
+++ b/app/src/components/dashboard/InsightsTab.tsx
@@ -2,14 +2,18 @@
  * InsightsTab — Parent behavioural dashboard for each child.
  *
  * Layout order:
- *  1. Child selector (multi-child only)
- *  2. Period toggle
+ *  1. Family Audit card (monthly, family-wide AI rollup)
+ *  2. Mentor section    — carousel when > 1 card (weekly, per-child AI briefing —
+ *                          kept adjacent to the Family Audit card above)
  *  3. Balance bar (available | allocated savings | lifetime)
  *  4. Sparkline cards  (Responsibility · Consistency · Savings)
  *  5. Effort preference tag
- *  6. Mentor section   — carousel when > 1 card
- *  7. Learning Lab     (learning_lab_enabled only)
- *  8. Progress Summary stats
+ *  6. Learning Lab     (learning_lab_enabled only)
+ *  7. Progress Summary stats
+ *
+ * The period toggle ("This week / This month / All time") is rendered as a
+ * fixed bar in the thumb zone, just above the bottom nav — not part of the
+ * scrolling content order above.
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react'
@@ -74,22 +78,29 @@ export function InsightsTab({ familyId, child }: Props) {
 
       <FamilyAuditCard familyId={familyId} />
 
-      {/* ── Period toggle ── */}
-      <div className="flex gap-1.5 bg-[var(--color-surface-alt)] rounded-xl p-1">
-        {(Object.keys(PERIOD_LABELS) as Period[]).map(p => (
-          <button
-            key={p}
-            onClick={() => setPeriod(p)}
-            className={`
-              tap-target-44 flex-1 py-1.5 rounded-lg text-[12px] font-semibold transition-all duration-150 cursor-pointer
-              ${period === p
-                ? 'bg-[var(--color-surface)] text-[var(--color-text)] shadow-sm'
-                : 'text-[var(--color-text-muted)] hover:text-[var(--color-text)]'}
-            `}
-          >
-            {PERIOD_LABELS[p]}
-          </button>
-        ))}
+      {/* ── Period toggle — fixed in the thumb zone, just above the bottom nav ── */}
+      <div className="fixed bottom-0 inset-x-0 z-20 flex justify-center pointer-events-none">
+        <div
+          className="pointer-events-auto w-full max-w-[520px] mx-3"
+          style={{ marginBottom: 'calc(max(12px, env(safe-area-inset-bottom)) + 68px)' }}
+        >
+          <div className="flex gap-1.5 bg-[var(--color-surface-alt)] rounded-xl p-1 shadow-lg border border-[var(--color-border)]">
+            {(Object.keys(PERIOD_LABELS) as Period[]).map(p => (
+              <button
+                key={p}
+                onClick={() => setPeriod(p)}
+                className={`
+                  tap-target-44 flex-1 py-1.5 rounded-lg text-[12px] font-semibold transition-all duration-150 cursor-pointer
+                  ${period === p
+                    ? 'bg-[var(--color-surface)] text-[var(--color-text)] shadow-sm'
+                    : 'text-[var(--color-text-muted)] hover:text-[var(--color-text)]'}
+                `}
+              >
+                {PERIOD_LABELS[p]}
+              </button>
+            ))}
+          </div>
+        </div>
       </div>
 
       {loading ? (
@@ -141,10 +152,24 @@ function InsightsDashboard({
         </div>
       )}
 
-      {/* 1. Balance bar */}
+      {/* 1. Premium Mentor section — kept adjacent to FamilyAuditCard above */}
+      <MentorSection data={data} child={child} period={period} onViewTrends={() => {
+        // Open the metric with the largest absolute trend delta
+        const t = data.trends
+        if (!t) { setExpandedMetric('consistency'); return }
+        const candidates: ['responsibility' | 'consistency' | 'savings', number][] = [
+          ['responsibility', Math.abs(t.responsibility?.delta ?? 0)],
+          ['consistency',    Math.abs(t.consistency?.delta    ?? 0)],
+          ['savings',        Math.abs(t.horizon?.delta        ?? 0)],
+        ]
+        candidates.sort((a, b) => b[1] - a[1])
+        setExpandedMetric(candidates[0][0])
+      }} />
+
+      {/* 2. Balance bar */}
       <BalanceBar data={data} currency={currency} />
 
-      {/* 2. Sparkline cards */}
+      {/* 3. Sparkline cards */}
       <div className="grid grid-cols-3 gap-2.5">
         <SparklineCard
           label="Responsibility"
@@ -175,24 +200,10 @@ function InsightsDashboard({
         />
       </div>
 
-      {/* 3. Effort preference tag */}
+      {/* 4. Effort preference tag */}
       {!data.is_discovery_phase && data.effort_preference && (
         <EffortTag preference={data.effort_preference} child={child} />
       )}
-
-      {/* 4. Premium Mentor section */}
-      <MentorSection data={data} child={child} period={period} onViewTrends={() => {
-        // Open the metric with the largest absolute trend delta
-        const t = data.trends
-        if (!t) { setExpandedMetric('consistency'); return }
-        const candidates: ['responsibility' | 'consistency' | 'savings', number][] = [
-          ['responsibility', Math.abs(t.responsibility?.delta ?? 0)],
-          ['consistency',    Math.abs(t.consistency?.delta    ?? 0)],
-          ['savings',        Math.abs(t.horizon?.delta        ?? 0)],
-        ]
-        candidates.sort((a, b) => b[1] - a[1])
-        setExpandedMetric(candidates[0][0])
-      }} />
 
       {/* 5. Child nudge summary — what the AI sent to the child this week */}
       {childNudgeSummary && (

--- a/app/src/components/dashboard/InsightsTab.tsx
+++ b/app/src/components/dashboard/InsightsTab.tsx
@@ -434,7 +434,7 @@ function DiscoveryCard({ data, name }: { data: InsightsData; name: string }) {
             <MentorAvatar />
             <div>
               <div className="flex items-center gap-2 mb-0.5">
-                <span className="text-[10px] font-bold tracking-widest uppercase" style={{ color: '#9ca3af' }}>
+                <span className="text-[10px] font-bold tracking-widest uppercase" style={{ color: '#6b9e87' }}>
                   Orchard Mentor
                 </span>
                 <span className="inline-block w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse" />

--- a/app/src/components/dashboard/InsightsTab.tsx
+++ b/app/src/components/dashboard/InsightsTab.tsx
@@ -22,6 +22,7 @@ import { SparklineCard } from './SparklineCard'
 import { SparklineExpanded } from './SparklineExpanded'
 import { LabSection } from './LabSection'
 import { AnimatedStat } from './AnimatedStat'
+import { FamilyAuditCard } from './FamilyAuditCard'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -70,6 +71,8 @@ export function InsightsTab({ familyId, child }: Props) {
 
   return (
     <div className="space-y-4">
+
+      <FamilyAuditCard familyId={familyId} />
 
       {/* ── Period toggle ── */}
       <div className="flex gap-1.5 bg-[var(--color-surface-alt)] rounded-xl p-1">

--- a/app/src/components/dashboard/__tests__/FamilyAuditCard.test.tsx
+++ b/app/src/components/dashboard/__tests__/FamilyAuditCard.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { FamilyAuditCard } from '../FamilyAuditCard'
+import * as api from '../../../lib/api'
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('FamilyAuditCard', () => {
+  it('renders totals and observation text when data is present', async () => {
+    vi.spyOn(api, 'getFamilyAudit').mockResolvedValue({
+      month: '2026-07',
+      totals: { total_earned_pence: 5000, total_spent_pence: 2000, total_saved_pence: 1500, total_given_pence: 500 },
+      flagged_child_id: 'c1',
+      flagged_pillar: 'PILLAR_4_CAPITAL_MANAGEMENT',
+      observation: 'We noted a stable month.',
+      behavioral_root: 'Pillar 4 — Capital Management: test root.',
+      the_action: 'You might consider a test action.',
+      source: 'ai',
+    })
+
+    render(<FamilyAuditCard familyId="fam1" />)
+
+    await waitFor(() => expect(screen.getByText('We noted a stable month.')).toBeTruthy())
+    expect(screen.getByText('£50.00')).toBeTruthy()
+    expect(screen.getByText('AI-generated')).toBeTruthy()
+  })
+
+  it('renders nothing when the family has no data yet this month', async () => {
+    vi.spyOn(api, 'getFamilyAudit').mockResolvedValue({ month: '2026-07', is_empty: true })
+
+    const { container } = render(<FamilyAuditCard familyId="fam1" />)
+
+    await waitFor(() => expect(container.firstChild).toBeNull())
+  })
+})

--- a/app/src/components/ui/PremiumShell.tsx
+++ b/app/src/components/ui/PremiumShell.tsx
@@ -110,3 +110,22 @@ export function ProBadge() {
     </span>
   )
 }
+
+/**
+ * EU AI Act Article 50 disclosure — shown on every card whose content is
+ * genuinely AI-generated (never on deterministic rule-based fallback text).
+ */
+export function AiDisclosurePill() {
+  return (
+    <span
+      className="text-[9px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded-full"
+      style={{
+        background: 'rgba(255,255,255,0.08)',
+        color:      'rgba(164,196,181,0.85)',
+        border:     '1px solid rgba(255,255,255,0.1)',
+      }}
+    >
+      AI-generated
+    </span>
+  )
+}

--- a/app/src/components/ui/__tests__/PremiumShell.test.tsx
+++ b/app/src/components/ui/__tests__/PremiumShell.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react'
+import { AiDisclosurePill } from '../PremiumShell'
+import { describe, it, expect } from 'vitest'
+
+describe('AiDisclosurePill', () => {
+  it('renders the AI-generated disclosure text', () => {
+    render(<AiDisclosurePill />)
+    expect(screen.getByText('AI-generated')).toBeTruthy()
+  })
+})

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -1321,3 +1321,28 @@ export async function dismissChildNudge(nudgeId: number): Promise<{ ok: boolean 
     body: JSON.stringify({ nudge_id: nudgeId }),
   });
 }
+
+// ----------------------------------------------------------------
+// Family Audit
+// ----------------------------------------------------------------
+
+export interface FamilyAuditData {
+  month:             string;
+  is_empty?:         boolean;
+  totals?: {
+    total_earned_pence: number;
+    total_spent_pence:  number;
+    total_saved_pence:  number;
+    total_given_pence:  number;
+  };
+  flagged_child_id?:   string;
+  flagged_pillar?:     string;
+  observation?:        string;
+  behavioral_root?:    string;
+  the_action?:         string;
+  source?:             'ai' | 'rule_based';
+}
+
+export async function getFamilyAudit(family_id: string): Promise<FamilyAuditData> {
+  return request(`/api/family-audit?family_id=${family_id}`);
+}

--- a/docs/superpowers/plans/2026-07-07-balance-math-shared-fix.md
+++ b/docs/superpowers/plans/2026-07-07-balance-math-shared-fix.md
@@ -1,0 +1,215 @@
+# Balance-Math Shared Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix two independent bugs in per-child available-balance SQL (missing `verification_status` filter in `insights.ts`; missing `reversal` debit in `family-audit.ts`) by extracting one shared, correct helper both routes call.
+
+**Architecture:** New pure-ish helper `getAvailableBalancePence(db, familyId, childId)` in `worker/src/lib/ledgerBalance.ts`, encoding the canonical formula already used correctly in `jars.ts`/`finance.ts`. Both `insights.ts` and `family-audit.ts` replace their inline SQL with a call to this helper.
+
+**Tech Stack:** Cloudflare Workers (TypeScript), D1 (SQLite), Vitest.
+
+## Global Constraints
+
+- Never use `--local` on any wrangler command (dead per project CLAUDE.md).
+- The canonical balance formula (from `jars.ts:89-99`, `finance.ts:397-414`): `SUM(credit) − SUM(reversal + payment)`, filtered to `verification_status IN ('verified_auto','verified_manual')`.
+- Do not touch `jars.ts` or `finance.ts` — already correct, out of spec scope.
+- Do not change `total_earned_pence` / `lifetime_earned_pence` in either file — different metric, out of scope.
+
+---
+
+### Task 1: Add `getAvailableBalancePence` helper
+
+**Files:**
+- Create: `worker/src/lib/ledgerBalance.ts`
+- Test: `worker/src/lib/ledgerBalance.test.ts`
+- Modify: `worker/src/routes/insights.ts:196-202`
+- Modify: `worker/src/routes/family-audit.ts:97-108`
+
+**Interfaces:**
+- Produces: `getAvailableBalancePence(db: D1Database, familyId: string, childId: string): Promise<number>` — later tasks (none in this plan) can rely on this exact name/signature.
+
+This task has no pure-logic unit to TDD against a mock `D1Database` cheaply (the existing convention — see `jar-balance.ts`, which also has no test file — is to skip a unit test for a single SQL-bound helper and instead verify via callers/integration). Given that, this task is verified by: (a) a compile-time check that the two call sites type-check against the new signature, and (b) a manual D1 spot-check after deploy. There is no Task-level TDD red/green cycle here because there is no D1 test harness in this repo (confirmed: no `vitest` D1 mock exists in `worker/src/lib/*.test.ts`).
+
+- [ ] **Step 1: Create the helper file**
+
+Create `worker/src/lib/ledgerBalance.ts`:
+
+```ts
+// worker/src/lib/ledgerBalance.ts
+//
+// Canonical "available balance" formula for a child's ledger. Single
+// source of truth — insights.ts and family-audit.ts both call this instead
+// of duplicating the SQL, after a 2026-07 audit found each had drifted
+// from the correct formula independently (see
+// docs/superpowers/specs/2026-07-07-balance-math-shared-fix-design.md).
+
+import type { D1Database } from '@cloudflare/workers-types';
+
+export async function getAvailableBalancePence(
+  db: D1Database,
+  familyId: string,
+  childId: string,
+): Promise<number> {
+  const row = await db.prepare(`
+    SELECT COALESCE(SUM(
+      CASE entry_type
+        WHEN 'credit'   THEN amount
+        WHEN 'reversal' THEN -amount
+        WHEN 'payment'  THEN -amount
+        ELSE 0
+      END
+    ), 0) AS bal
+    FROM ledger WHERE family_id = ? AND child_id = ?
+      AND verification_status IN ('verified_auto', 'verified_manual')
+  `).bind(familyId, childId).first<{ bal: number }>();
+  return row?.bal ?? 0;
+}
+```
+
+- [ ] **Step 2: Update `insights.ts` to use the helper**
+
+In `worker/src/routes/insights.ts`, add the import near the top (alongside the existing `jar-balance.js` import at line 28):
+
+```ts
+import { getAvailableBalancePence } from '../lib/ledgerBalance.js';
+```
+
+Replace the `balanceRow` entry inside the `Promise.all` at lines 195-202 (the block currently reading):
+
+```ts
+    // Available balance: sum of credits minus debits from ledger
+    env.DB.prepare(`
+      SELECT
+        COALESCE(SUM(CASE WHEN entry_type = 'credit' THEN amount ELSE -amount END), 0) AS available
+      FROM ledger
+      WHERE family_id = ? AND child_id = ?
+    `).bind(family_id, effectiveChildId)
+      .first<{ available: number }>(),
+```
+
+with a placeholder `Promise.resolve(null)` in that array slot, and compute the balance separately right after the `Promise.all`:
+
+```ts
+    Promise.resolve(null),
+```
+
+Then, immediately after the destructured `const [earnedRow, spentRow, savedRow, balanceRow, lifetimeRow, goalsRow] = await Promise.all([...])` block, replace the line
+
+```ts
+  const availableBal  = balanceRow?.available ?? 0;
+```
+
+with:
+
+```ts
+  const availableBal  = await getAvailableBalancePence(env.DB, family_id, effectiveChildId);
+```
+
+Remove the now-unused `balanceRow` destructure slot by renaming it `_balanceRowUnused` is not acceptable style-wise — instead, drop it from both the `Promise.all` array and the destructure entirely:
+
+Final destructure line becomes:
+
+```ts
+  const [earnedRow, spentRow, savedRow, lifetimeRow, goalsRow] = await Promise.all([
+```
+
+(i.e. remove the `balanceRow` slot and its corresponding `Promise` entry from the array — do not leave a `Promise.resolve(null)` placeholder; just delete that array element entirely, since nothing else in the array depends on positional order beyond the destructure itself).
+
+- [ ] **Step 3: Update `family-audit.ts` to use the helper**
+
+In `worker/src/routes/family-audit.ts`, add the import (alongside the existing `familyAudit.js` import at line 16-19):
+
+```ts
+import { getAvailableBalancePence } from '../lib/ledgerBalance.js';
+```
+
+Replace the `balRow` query inside the per-child loop (lines 97-108):
+
+```ts
+    const [balRow, goalsRow, completionRow] = await Promise.all([
+      env.DB.prepare(`
+        SELECT COALESCE(SUM(
+          CASE entry_type
+            WHEN 'credit'  THEN amount
+            WHEN 'payment' THEN -amount
+            ELSE 0
+          END
+        ),0) AS bal
+        FROM ledger WHERE family_id=? AND child_id=?
+          AND verification_status IN ('verified_auto','verified_manual')
+      `).bind(family_id, childId).first<{ bal: number }>(),
+
+      env.DB.prepare(`
+        SELECT COALESCE(SUM(target_amount - current_saved_pence),0) AS locked
+        FROM goals WHERE family_id=? AND child_id=? AND archived=0 AND target_amount > current_saved_pence
+      `).bind(family_id, childId).first<{ locked: number }>().catch(() => ({ locked: 0 })),
+
+      env.DB.prepare(`
+        SELECT COUNT(*) AS total, SUM(CASE WHEN attempt_count=1 THEN 1 ELSE 0 END) AS first_time
+        FROM completions WHERE family_id=? AND child_id=? AND status='completed' AND resolved_at >= ?
+      `).bind(family_id, childId, monthStart).first<{ total: number; first_time: number }>(),
+    ]);
+
+    const availableBal    = Math.max(0, balRow?.bal ?? 0);
+```
+
+with:
+
+```ts
+    const [availableBalRaw, goalsRow, completionRow] = await Promise.all([
+      getAvailableBalancePence(env.DB, family_id, childId),
+
+      env.DB.prepare(`
+        SELECT COALESCE(SUM(target_amount - current_saved_pence),0) AS locked
+        FROM goals WHERE family_id=? AND child_id=? AND archived=0 AND target_amount > current_saved_pence
+      `).bind(family_id, childId).first<{ locked: number }>().catch(() => ({ locked: 0 })),
+
+      env.DB.prepare(`
+        SELECT COUNT(*) AS total, SUM(CASE WHEN attempt_count=1 THEN 1 ELSE 0 END) AS first_time
+        FROM completions WHERE family_id=? AND child_id=? AND status='completed' AND resolved_at >= ?
+      `).bind(family_id, childId, monthStart).first<{ total: number; first_time: number }>(),
+    ]);
+
+    const availableBal    = Math.max(0, availableBalRaw);
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `cd worker && npx tsc --noEmit`
+Expected: no errors. This confirms both call sites match the new helper's signature and that removing `balanceRow` from `insights.ts` didn't break any other reference.
+
+- [ ] **Step 5: Run the existing worker test suite**
+
+Run: `cd worker && npx vitest run`
+Expected: all existing tests pass (this change touches no tested pure-logic function, so this is a regression guard, not new coverage).
+
+- [ ] **Step 6: Manual D1 spot-check against morechard-dev**
+
+Run against a child known to have at least one `disputed`/`reversed` ledger entry (check first with a SELECT):
+
+```bash
+cd worker
+npx wrangler d1 execute morechard-dev --remote --command="SELECT id, child_id, entry_type, amount, verification_status FROM ledger WHERE verification_status IN ('disputed','reversed') LIMIT 5"
+```
+
+Pick one `child_id`/`family_id` pair from that result, then hit the real endpoints (via the running dev server, `npm run dev`) for that child's `GET /api/insights` and that family's `GET /api/family-audit`, and confirm `available_balance_pence` no longer includes the disputed/reversed entry's amount, and that the two endpoints agree with each other for the same child (modulo goals-locked, which family-audit doesn't surface directly — compare via `Math.max(0, availableBalRaw)` you can add as a temporary console.log if needed, then remove it).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add worker/src/lib/ledgerBalance.ts worker/src/routes/insights.ts worker/src/routes/family-audit.ts
+git commit -m "fix: unify available-balance formula across insights and family-audit
+
+insights.ts was missing the verification_status filter (pending/disputed/
+reversed entries leaked into the balance); family-audit.ts was missing
+'reversal' as a debit (reversed credits stayed counted). Both now share
+getAvailableBalancePence() in lib/ledgerBalance.ts."
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** The spec's single deliverable (shared helper, both call sites updated) is fully covered by Task 1. No `jars.ts`/`finance.ts` changes were introduced (out of scope, confirmed). No `total_earned_pence`/`lifetime_earned_pence` changes were introduced (out of scope, confirmed).
+- **Placeholder scan:** No TBD/TODO. Step 6 is a manual verification step (not a red/green unit test) because this repo has no D1 test harness for SQL-bound helpers — this mirrors the existing convention for `jar-balance.ts`, which also ships without a test file.
+- **Type consistency:** `getAvailableBalancePence` returns `Promise<number>` everywhere it's referenced (Task 1, Steps 1-3) — no signature drift between definition and call sites.

--- a/docs/superpowers/plans/2026-07-07-discovery-card-ai-upgrade.md
+++ b/docs/superpowers/plans/2026-07-07-discovery-card-ai-upgrade.md
@@ -1,0 +1,624 @@
+# Discovery Card AI Upgrade Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the Discovery Phase card's 100%-static template text with an AI-generated (gpt-4o-mini, rule-based fallback) intro + up-to-3-item action list, driven by the child's actual setup state (chores assigned, goal exists, photo check-in on), cached per child and regenerated only when that setup state changes.
+
+**Architecture:** Pure setup-signal logic (candidate menu, signature builder, rule-based fallback text) lives in `worker/src/lib/discoveryBriefing.ts`, mirroring the existing `familyAudit.ts` pattern (DB-free, unit-testable). `insights.ts` queries live setup facts on every request while `is_discovery_phase`, compares against a cached `discovery_briefings` row keyed by `child_id`, and only calls the LLM when the setup signature has changed. The frontend `DiscoveryCard` renders whatever the API returns instead of hardcoded JSX text.
+
+**Tech Stack:** Cloudflare Workers (TypeScript), D1 (SQLite), OpenAI `gpt-4o-mini`, React (Vite app), Vitest.
+
+## Global Constraints
+
+- Never use `--local` on any wrangler command (dead per project CLAUDE.md).
+- Migrations containing no triggers use `wrangler d1 migrations apply` (this one has none).
+- EU AI Act Article 50 disclosure: `<AiDisclosurePill />` must render whenever content's `source === 'ai'` — same component, same condition pattern as `LiveBriefingCard` and `FamilyAuditCard`.
+- English only — no Polish localisation for this card's AI content, matching the precedent already shipped in `family-audit.ts` (which also does not localise; only the weekly per-child briefing does).
+- Do not change the Discovery Phase threshold (`allTimeCompleted < 3 || daysSinceFirst < 7`) or the progress ring — out of spec scope.
+
+---
+
+### Task 1: `discoveryBriefing.ts` — pure setup-signal logic
+
+**Files:**
+- Create: `worker/src/lib/discoveryBriefing.ts`
+- Test: `worker/src/lib/discoveryBriefing.test.ts`
+
+**Interfaces:**
+- Produces (used by Task 2):
+  - `type DiscoveryCandidateKey = 'ASSIGN_MORE_CHORES' | 'SET_A_GOAL' | 'ENABLE_PHOTO_CHECKIN'`
+  - `interface DiscoverySetupFacts { chore_count: number; has_proof_required_chore: boolean; has_active_goal: boolean; jars_enabled: boolean }`
+  - `interface DiscoveryBriefingContent { intro: string; actions: string[] }`
+  - `buildSetupSignature(facts: DiscoverySetupFacts): string`
+  - `getOutstandingCandidates(facts: DiscoverySetupFacts): DiscoveryCandidateKey[]`
+  - `buildRuleBasedDiscoveryBriefing(childName: string, outstanding: DiscoveryCandidateKey[]): DiscoveryBriefingContent`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `worker/src/lib/discoveryBriefing.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  buildSetupSignature, getOutstandingCandidates, buildRuleBasedDiscoveryBriefing,
+  type DiscoverySetupFacts,
+} from './discoveryBriefing.js';
+
+const allDone: DiscoverySetupFacts = {
+  chore_count: 3, has_proof_required_chore: true, has_active_goal: true, jars_enabled: true,
+};
+const noneDone: DiscoverySetupFacts = {
+  chore_count: 0, has_proof_required_chore: false, has_active_goal: false, jars_enabled: false,
+};
+
+describe('buildSetupSignature', () => {
+  it('produces a stable signature for the same facts', () => {
+    expect(buildSetupSignature(allDone)).toBe(buildSetupSignature({ ...allDone }));
+  });
+
+  it('changes when chore_count crosses the 3-chore threshold', () => {
+    const below = buildSetupSignature({ ...allDone, chore_count: 2 });
+    const above = buildSetupSignature({ ...allDone, chore_count: 3 });
+    expect(below).not.toBe(above);
+  });
+
+  it('does not change when chore_count changes within the same side of the threshold', () => {
+    const a = buildSetupSignature({ ...allDone, chore_count: 5 });
+    const b = buildSetupSignature({ ...allDone, chore_count: 9 });
+    expect(a).toBe(b);
+  });
+
+  it('changes when has_active_goal flips', () => {
+    const withGoal    = buildSetupSignature(allDone);
+    const withoutGoal = buildSetupSignature({ ...allDone, has_active_goal: false });
+    expect(withGoal).not.toBe(withoutGoal);
+  });
+});
+
+describe('getOutstandingCandidates', () => {
+  it('returns all three candidates when nothing is set up', () => {
+    expect(getOutstandingCandidates(noneDone)).toEqual([
+      'ASSIGN_MORE_CHORES', 'SET_A_GOAL', 'ENABLE_PHOTO_CHECKIN',
+    ]);
+  });
+
+  it('returns an empty array when everything is set up', () => {
+    expect(getOutstandingCandidates(allDone)).toEqual([]);
+  });
+
+  it('omits ASSIGN_MORE_CHORES once 3 or more chores are assigned', () => {
+    const result = getOutstandingCandidates({ ...noneDone, chore_count: 3 });
+    expect(result).not.toContain('ASSIGN_MORE_CHORES');
+  });
+
+  it('omits SET_A_GOAL once an active goal exists', () => {
+    const result = getOutstandingCandidates({ ...noneDone, has_active_goal: true });
+    expect(result).not.toContain('SET_A_GOAL');
+  });
+
+  it('omits ENABLE_PHOTO_CHECKIN once a proof-required chore exists', () => {
+    const result = getOutstandingCandidates({ ...noneDone, has_proof_required_chore: true });
+    expect(result).not.toContain('ENABLE_PHOTO_CHECKIN');
+  });
+});
+
+describe('buildRuleBasedDiscoveryBriefing', () => {
+  it('returns one action per outstanding candidate, in the given order', () => {
+    const result = buildRuleBasedDiscoveryBriefing('Mia', ['SET_A_GOAL', 'ENABLE_PHOTO_CHECKIN']);
+    expect(result.actions).toHaveLength(2);
+    expect(result.actions[0]).toContain('Mia');
+    expect(result.actions[1]).toContain('Mia');
+  });
+
+  it('returns an empty actions array and a "fully set up" intro when nothing is outstanding', () => {
+    const result = buildRuleBasedDiscoveryBriefing('Mia', []);
+    expect(result.actions).toEqual([]);
+    expect(result.intro.toLowerCase()).toContain('set up');
+  });
+
+  it('never returns more than 3 actions', () => {
+    const result = buildRuleBasedDiscoveryBriefing('Mia', [
+      'ASSIGN_MORE_CHORES', 'SET_A_GOAL', 'ENABLE_PHOTO_CHECKIN',
+    ]);
+    expect(result.actions.length).toBeLessThanOrEqual(3);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd worker && npx vitest run src/lib/discoveryBriefing.test.ts`
+Expected: FAIL — `Cannot find module './discoveryBriefing.js'`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `worker/src/lib/discoveryBriefing.ts`:
+
+```ts
+// worker/src/lib/discoveryBriefing.ts
+//
+// Pure, DB-free logic for the Discovery Phase card (parent Insights tab).
+// Kept separate from the route handler so the candidate menu, signature
+// builder, and rule-based fallback text can be unit tested without a D1
+// binding — mirrors the pattern established in familyAudit.ts.
+
+export type DiscoveryCandidateKey =
+  | 'ASSIGN_MORE_CHORES'
+  | 'SET_A_GOAL'
+  | 'ENABLE_PHOTO_CHECKIN';
+
+export interface DiscoverySetupFacts {
+  chore_count:              number;
+  has_proof_required_chore: boolean;
+  has_active_goal:          boolean;
+  jars_enabled:              boolean;
+}
+
+export interface DiscoveryBriefingContent {
+  intro:   string;
+  actions: string[];
+}
+
+/**
+ * A short, deterministic string that changes only when a candidate's
+ * fire-state would change (crossing the 3-chore threshold, a goal
+ * appearing/disappearing, etc). Not a cryptographic hash — just enough to
+ * detect "something relevant changed" so insights.ts knows when to
+ * regenerate the cached briefing.
+ */
+export function buildSetupSignature(facts: DiscoverySetupFacts): string {
+  return [
+    facts.chore_count >= 3 ? '1' : '0',
+    facts.has_proof_required_chore ? '1' : '0',
+    facts.has_active_goal ? '1' : '0',
+    facts.jars_enabled ? '1' : '0',
+  ].join('');
+}
+
+/** Which onboarding steps are still outstanding for this child, in priority order. */
+export function getOutstandingCandidates(facts: DiscoverySetupFacts): DiscoveryCandidateKey[] {
+  const out: DiscoveryCandidateKey[] = [];
+  if (facts.chore_count < 3) out.push('ASSIGN_MORE_CHORES');
+  if (!facts.has_active_goal) out.push('SET_A_GOAL');
+  if (!facts.has_proof_required_chore) out.push('ENABLE_PHOTO_CHECKIN');
+  return out;
+}
+
+const CANDIDATE_TEXT: Record<DiscoveryCandidateKey, (childName: string) => string> = {
+  ASSIGN_MORE_CHORES:   (name) => `Assign 2–3 small daily tasks so I can spot ${name}'s consistency patterns.`,
+  SET_A_GOAL:           (name) => `Help ${name} set a savings goal — even a small one — so I can track their planning instincts.`,
+  ENABLE_PHOTO_CHECKIN: (_name) => 'Turn on photo check-in for one task, so I can measure follow-through accurately.',
+};
+
+/** Deterministic fallback text — used when the LLM call errors or times out. */
+export function buildRuleBasedDiscoveryBriefing(
+  childName:   string,
+  outstanding: DiscoveryCandidateKey[],
+): DiscoveryBriefingContent {
+  if (outstanding.length === 0) {
+    return {
+      intro: `I'm building a picture of how ${childName} approaches their responsibilities. ` +
+             `Everything's set up on your end — once ${childName} has a few completed tasks, ` +
+             `I'll have enough to give you genuinely useful, specific coaching.`,
+      actions: [],
+    };
+  }
+
+  const intro = `I'm building a picture of how ${childName} approaches their responsibilities. ` +
+                `Once I've seen a few more completed tasks, I'll have enough to give you genuinely ` +
+                `useful, specific coaching — not generic tips. To speed this up, try ` +
+                `${outstanding.length === 1 ? 'this' : 'these'} this week:`;
+
+  const actions = outstanding.slice(0, 3).map(key => CANDIDATE_TEXT[key](childName));
+
+  return { intro, actions };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd worker && npx vitest run src/lib/discoveryBriefing.test.ts`
+Expected: PASS — all 11 tests green.
+
+- [ ] **Step 5: Create the migration**
+
+Create `worker/migrations/0077_discovery_briefings.sql`:
+
+```sql
+-- 0077_discovery_briefings.sql
+-- AI-generated Discovery Phase card content (parent Insights tab),
+-- cached one row per child, regenerated when setup_signature changes.
+
+CREATE TABLE IF NOT EXISTS discovery_briefings (
+  child_id         TEXT PRIMARY KEY REFERENCES users(id),
+  family_id        TEXT NOT NULL REFERENCES families(id),
+  setup_signature  TEXT NOT NULL,
+  intro            TEXT NOT NULL,
+  actions          TEXT NOT NULL,   -- JSON array of strings
+  source           TEXT NOT NULL DEFAULT 'rule_based' CHECK (source IN ('rule_based','ai')),
+  created_at       INTEGER NOT NULL DEFAULT (unixepoch())
+);
+```
+
+Apply it to the dev database:
+
+```bash
+cd worker
+npx wrangler d1 migrations apply morechard-dev --remote
+```
+
+Expected: `discovery_briefings` listed as applied.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add worker/src/lib/discoveryBriefing.ts worker/src/lib/discoveryBriefing.test.ts worker/migrations/0077_discovery_briefings.sql
+git commit -m "feat: add discoveryBriefing lib and discovery_briefings table
+
+Pure setup-signal logic (candidate menu, signature builder, rule-based
+fallback) for the Discovery Phase card, unit tested without a D1 binding."
+```
+
+---
+
+### Task 2: `insights.ts` — setup facts, caching, and AI generation
+
+**Files:**
+- Modify: `worker/src/routes/insights.ts`
+
+**Interfaces:**
+- Consumes: `buildSetupSignature`, `getOutstandingCandidates`, `buildRuleBasedDiscoveryBriefing`, `DiscoverySetupFacts`, `DiscoveryCandidateKey`, `DiscoveryBriefingContent` from Task 1.
+- Consumes: `captureAiGeneration(env, props)` from `worker/src/lib/posthog.js` (already imported in this file).
+- Produces: adds `discovery_briefing: (DiscoveryBriefingContent & { source: 'ai' | 'rule_based' }) | null` to the `GET /api/insights` JSON response — Task 3's frontend type must match this shape exactly.
+
+No isolated unit test for this task (same rationale as the balance-math plan: it's D1-bound route logic with no existing D1 test harness in this repo). Verified via Steps 4-5 (typecheck + manual dev-server check).
+
+- [ ] **Step 1: Add the import**
+
+In `worker/src/routes/insights.ts`, add near the existing `jar-balance.js` import (line 28):
+
+```ts
+import {
+  buildSetupSignature, getOutstandingCandidates, buildRuleBasedDiscoveryBriefing,
+  type DiscoverySetupFacts, type DiscoveryCandidateKey, type DiscoveryBriefingContent,
+} from '../lib/discoveryBriefing.js';
+```
+
+- [ ] **Step 2: Insert the Discovery Briefing section**
+
+In `worker/src/routes/insights.ts`, immediately after the `// ── 8. Velocity Context (view_mode-aware) & Locale ──` block ends (i.e. right after the `velocityContext` const, which is defined just before the existing `// ── 9. Orchard Lead Mentor Briefing` comment at line 357), insert:
+
+```ts
+  // ── 8b. Discovery Briefing (Discovery Phase only) ────────────────────────
+  let discoveryBriefing: (DiscoveryBriefingContent & { source: 'ai' | 'rule_based' }) | null = null;
+
+  if (isDiscoveryPhase) {
+    const [choreRow, proofRow, goalRow, jarRow] = await Promise.all([
+      env.DB.prepare(`SELECT COUNT(*) AS cnt FROM chores WHERE assigned_to = ?`)
+        .bind(effectiveChildId).first<{ cnt: number }>(),
+      env.DB.prepare(`SELECT COUNT(*) AS cnt FROM chores WHERE assigned_to = ? AND proof_required = 1`)
+        .bind(effectiveChildId).first<{ cnt: number }>(),
+      env.DB.prepare(`SELECT COUNT(*) AS cnt FROM goals WHERE child_id = ? AND archived = 0`)
+        .bind(effectiveChildId).first<{ cnt: number }>(),
+      env.DB.prepare(`SELECT enabled FROM jar_config WHERE family_id = ? AND child_id = ?`)
+        .bind(family_id, effectiveChildId).first<{ enabled: number }>(),
+    ]);
+
+    const setupFacts: DiscoverySetupFacts = {
+      chore_count:              choreRow?.cnt ?? 0,
+      has_proof_required_chore: (proofRow?.cnt ?? 0) > 0,
+      has_active_goal:          (goalRow?.cnt ?? 0) > 0,
+      jars_enabled:              (jarRow?.enabled ?? 0) === 1,
+    };
+    const signature = buildSetupSignature(setupFacts);
+
+    const cachedDiscovery = await env.DB.prepare(`
+      SELECT setup_signature, intro, actions, source FROM discovery_briefings WHERE child_id = ?
+    `).bind(effectiveChildId)
+      .first<{ setup_signature: string; intro: string; actions: string; source: 'ai' | 'rule_based' }>();
+
+    if (cachedDiscovery && cachedDiscovery.setup_signature === signature) {
+      discoveryBriefing = {
+        intro:   cachedDiscovery.intro,
+        actions: JSON.parse(cachedDiscovery.actions) as string[],
+        source:  cachedDiscovery.source,
+      };
+    } else {
+      const outstanding = getOutstandingCandidates(setupFacts);
+      const generated    = await generateDiscoveryBriefing(env, effectiveChildId, childName, outstanding);
+
+      await env.DB.prepare(`
+        INSERT INTO discovery_briefings (child_id, family_id, setup_signature, intro, actions, source)
+        VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(child_id) DO UPDATE SET
+          family_id       = excluded.family_id,
+          setup_signature = excluded.setup_signature,
+          intro           = excluded.intro,
+          actions         = excluded.actions,
+          source          = excluded.source,
+          created_at      = unixepoch()
+      `).bind(
+        effectiveChildId, family_id, signature,
+        generated.intro, JSON.stringify(generated.actions), generated.source,
+      ).run();
+
+      discoveryBriefing = generated;
+    }
+  }
+```
+
+- [ ] **Step 3: Add the field to the JSON response**
+
+In the `return json({...})` block at the end of `handleInsights` (around line 634-684), add the new field next to the existing `mentor_briefing` field:
+
+```ts
+    // AI Executive Briefing (null during Discovery Phase)
+    mentor_briefing: mentorBriefing,
+
+    // Discovery Phase onboarding briefing (null once past Discovery Phase)
+    discovery_briefing: discoveryBriefing,
+```
+
+- [ ] **Step 4: Add the `generateDiscoveryBriefing` function**
+
+In `worker/src/routes/insights.ts`, add this function directly after the existing `generateBriefing` function (which ends around line 1407, just before `// ── Jar Briefing Helpers ──`):
+
+```ts
+async function generateDiscoveryBriefing(
+  env:         Env,
+  childId:     string,
+  childName:   string,
+  outstanding: DiscoveryCandidateKey[],
+): Promise<DiscoveryBriefingContent & { source: 'ai' | 'rule_based' }> {
+  const systemPrompt = `You are the 'Orchard Lead', a collaborative financial coach for parents. \
+A child has just started on Morechard and has not yet completed enough tasks for real behavioural \
+coaching. Your job is to write a short, warm onboarding note for the parent.
+
+You are given a list of "outstanding" setup steps for this child — a subset of:
+- ASSIGN_MORE_CHORES: fewer than 3 chores are currently assigned to the child.
+- SET_A_GOAL: the child has no active savings goal.
+- ENABLE_PHOTO_CHECKIN: none of the child's chores require photo proof.
+
+CONSTRAINTS:
+- Only write about the steps in the given "outstanding" list. Never invent or mention a step that
+  is not listed — if a step isn't listed, treat it as already done and do not reference it.
+- If "outstanding" is an empty array, write ONLY a short intro telling the parent everything is
+  set up and you just need a few completions from the child to start coaching — return an empty
+  "actions" array in that case.
+- Use first-person singular ("I'm building a picture of...") — this note is from the Mentor
+  observing the child, distinct from the family-wide "We" voice used elsewhere in the app.
+- Tone: warm, professional, not childish. UK English.
+- Respond ONLY with a valid JSON object. No markdown, no commentary, no extra fields.
+
+Response schema (strict):
+{
+  "intro": "<1-2 sentences>",
+  "actions": ["<one sentence per outstanding step, same order as given, empty array if none>"]
+}`;
+
+  const userPrompt = JSON.stringify({ child_name: childName, outstanding });
+
+  const messages = [
+    { role: 'system', content: systemPrompt },
+    { role: 'user',   content: userPrompt },
+  ];
+  const traceId = crypto.randomUUID();
+  const t0      = Date.now();
+
+  try {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type':  'application/json',
+        'Authorization': `Bearer ${env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model:           'gpt-4o-mini',
+        messages,
+        max_tokens:      250,
+        response_format: { type: 'json_object' },
+      }),
+      signal: AbortSignal.timeout(10000),
+    });
+
+    if (!res.ok) throw new Error(`OpenAI ${res.status}`);
+
+    const data   = await res.json() as { choices: Array<{ message: { content: string } }> };
+    const raw    = data.choices[0]?.message?.content ?? '';
+    const parsed = JSON.parse(raw) as Partial<DiscoveryBriefingContent>;
+
+    if (!parsed.intro || !Array.isArray(parsed.actions)) {
+      throw new Error('Incomplete AI response schema');
+    }
+
+    captureAiGeneration(env, {
+      distinctId:     childId,
+      traceId,
+      spanName:       'discovery_briefing',
+      model:          'gpt-4o-mini',
+      provider:       'openai',
+      input:          messages,
+      outputText:     raw,
+      latencySeconds: (Date.now() - t0) / 1000,
+    });
+
+    return { intro: parsed.intro, actions: parsed.actions, source: 'ai' };
+  } catch (err) {
+    captureAiGeneration(env, {
+      distinctId:     childId,
+      traceId,
+      spanName:       'discovery_briefing',
+      model:          'gpt-4o-mini',
+      provider:       'openai',
+      input:          messages,
+      latencySeconds: (Date.now() - t0) / 1000,
+      isError:        true,
+      errorMessage:   err instanceof Error ? err.message : String(err),
+    });
+
+    return { ...buildRuleBasedDiscoveryBriefing(childName, outstanding), source: 'rule_based' };
+  }
+}
+```
+
+- [ ] **Step 5: Typecheck and run the worker test suite**
+
+Run: `cd worker && npx tsc --noEmit && npx vitest run`
+Expected: no type errors; all tests (including Task 1's 11 new tests) pass.
+
+- [ ] **Step 6: Manual verification against morechard-dev**
+
+Start the dev server (`npm run dev` from repo root), sign in as a parent whose child is in Discovery Phase (fewer than 3 completions), and load the Insights tab. Confirm in the network tab that `GET /api/insights` now returns a non-null `discovery_briefing` with `intro` and `actions`. Then, as that parent, assign a 3rd chore to the child (or add a goal, or enable photo check-in on a chore) and reload Insights — confirm `discovery_briefing.actions` no longer lists the step you just completed, and that a fresh D1 row was written:
+
+```bash
+cd worker
+npx wrangler d1 execute morechard-dev --remote --command="SELECT child_id, setup_signature, source, created_at FROM discovery_briefings ORDER BY created_at DESC LIMIT 5"
+```
+
+Expected: the row for your test child has an updated `setup_signature` and a newer `created_at` than before the setup change.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add worker/src/routes/insights.ts
+git commit -m "feat: generate AI-driven Discovery Phase briefing in GET /api/insights
+
+Setup state (chores assigned, goal exists, photo check-in on) is queried
+on every request during Discovery Phase and compared against a cached
+per-child signature; the LLM only runs when that signature changes."
+```
+
+---
+
+### Task 3: Frontend — `DiscoveryCard` renders the AI content
+
+**Files:**
+- Modify: `app/src/lib/api.ts` (add `discovery_briefing` to `InsightsData`)
+- Modify: `app/src/components/dashboard/InsightsTab.tsx:425-504` (`DiscoveryCard`, `DiscoveryAction`)
+
+**Interfaces:**
+- Consumes: `discovery_briefing: { intro: string; actions: string[]; source: 'ai' | 'rule_based' } | null` from Task 2's `GET /api/insights` response.
+
+No isolated component test for this task — matches the existing convention in this file (`LiveBriefingCard`, `MentorCarousel`, and the original `DiscoveryCard` are all un-exported local functions inside `InsightsTab.tsx` with no dedicated test file; only the standalone `FamilyAuditCard.tsx` file has one, because it's a separate exported module). Verified via Step 3 (typecheck) and Step 4 (manual browser check, continuing from Task 2 Step 6's dev server session).
+
+- [ ] **Step 1: Add the type field**
+
+In `app/src/lib/api.ts`, inside the `InsightsData` interface (around line 594, right after `mentor_briefing: MentorBriefing | null;`), add:
+
+```ts
+  discovery_briefing: { intro: string; actions: string[]; source: 'ai' | 'rule_based' } | null;
+```
+
+- [ ] **Step 2: Rewrite `DiscoveryCard` and `DiscoveryAction`**
+
+In `app/src/components/dashboard/InsightsTab.tsx`, replace the entire `DiscoveryCard` function and the `DiscoveryAction` function (lines 425-504) with:
+
+```tsx
+function DiscoveryCard({ data, name }: { data: InsightsData; name: string }) {
+  const briefing = data.discovery_briefing
+
+  return (
+    <PremiumShell>
+      <div className="px-4 pt-5 pb-4 relative z-10">
+
+        {/* Header row */}
+        <div className="flex items-start justify-between gap-3 mb-4">
+          <div className="flex items-center gap-3">
+            {/* Mentor avatar */}
+            <MentorAvatar />
+            <div>
+              <div className="flex items-center gap-2 mb-0.5">
+                <span className="text-[10px] font-bold tracking-widest uppercase" style={{ color: '#6b9e87' }}>
+                  Orchard Mentor
+                </span>
+                {briefing?.source === 'ai'
+                  ? <AiDisclosurePill />
+                  : <span className="inline-block w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse" />}
+              </div>
+              <p className="text-[15px] font-extrabold tracking-tight" style={{ color: '#f0fdf4' }}>
+                Getting to know {name}
+              </p>
+            </div>
+          </div>
+          {/* Progress ring — discovery state */}
+          <div className="relative w-9 h-9 shrink-0">
+            <svg width={36} height={36} viewBox="0 0 36 36">
+              <circle cx={18} cy={18} r={13} fill="none" stroke="rgba(255,255,255,0.07)" strokeWidth={4}/>
+              <circle cx={18} cy={18} r={13} fill="none" stroke="#0d9488" strokeWidth={4}
+                strokeDasharray={`${Math.round((Math.min(data.all_time_completed, 3) / 3) * 82)} 82`}
+                strokeLinecap="round"
+                transform="rotate(-90 18 18)"
+              />
+              <text x={18} y={22} textAnchor="middle" fontSize={8} fontWeight={700} fill="#0d9488">
+                {data.all_time_completed}/3
+              </text>
+            </svg>
+          </div>
+          <ProBadge />
+        </div>
+
+        {/* Body — advisor prose style */}
+        <p className="text-[13px] leading-relaxed mb-4" style={{ color: '#a7c4b5' }}>
+          {briefing
+            ? briefing.intro
+            : <>I'm building a picture of how <span style={{ color: '#e2f5ee', fontWeight: 600 }}>{name}</span> approaches their responsibilities.</>}
+        </p>
+
+        {/* Action list */}
+        {briefing && briefing.actions.length > 0 && (
+          <div className="space-y-2.5 mb-4">
+            {briefing.actions.map((text, i) => (
+              <DiscoveryAction key={i} step={String(i + 1).padStart(2, '0')} text={text} />
+            ))}
+          </div>
+        )}
+
+      </div>
+    </PremiumShell>
+  )
+}
+
+function DiscoveryAction({ step, text }: { step: string; text: string }) {
+  return (
+    <div className="flex items-start gap-3">
+      <span className="shrink-0 text-[9px] font-black tracking-wider tabular-nums mt-0.5"
+            style={{ color: '#0d9488' }}>
+        {step}
+      </span>
+      <p className="text-[12px] leading-relaxed" style={{ color: '#a7c4b5' }}>{text}</p>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: Typecheck and run the app test suite**
+
+Run: `cd app && npx tsc --noEmit && npx vitest run`
+Expected: no type errors; all existing tests pass (no test targets `DiscoveryCard` directly, so this is a regression guard for `FamilyAuditCard.test.tsx` and the other component tests, confirming the `InsightsData` type change didn't break anything).
+
+- [ ] **Step 4: Manual browser verification**
+
+With the dev server still running from Task 2 Step 6, reload the parent Insights tab for a child in Discovery Phase in an actual browser. Confirm:
+- The AI disclosure pill appears when `discovery_briefing.source === 'ai'` (check the network response to confirm which source came back).
+- The action list shows 1-3 items reflecting only what's actually outstanding — after completing Task 2 Step 6's manual test (assigning a 3rd chore / adding a goal / enabling photo check-in), confirm that action no longer appears.
+- If you temporarily set `OPENAI_API_KEY` to an invalid value to force the fallback path, confirm the card still renders correctly with rule-based text and no `AiDisclosurePill` (pulsing amber dot instead) — then restore the real key.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/lib/api.ts app/src/components/dashboard/InsightsTab.tsx
+git commit -m "feat: render AI-generated Discovery Phase content in DiscoveryCard
+
+Replaces the hardcoded intro paragraph and fixed 3-item action list with
+data from GET /api/insights' new discovery_briefing field; adds the AI
+disclosure pill matching LiveBriefingCard and FamilyAuditCard."
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** §1 (setup signal) → Task 1. §2 (data & caching) → migration in Task 1 Step 5, cache read/write in Task 2 Step 2. §3 (generation, candidate menu, fallback) → Task 1's `buildRuleBasedDiscoveryBriefing` + Task 2's `generateDiscoveryBriefing`. §4 (frontend, AI disclosure pill) → Task 3. Edge cases (zero chores, everything configured) → covered by Task 1's tests (`noneDone`/`allDone` fixtures) and Task 1's empty-outstanding branch in `buildRuleBasedDiscoveryBriefing`.
+- **Deviation from spec worth flagging:** the design spec's §3 says the prompt reuses `buildInsightsFamilyBlock` for family context. This plan's `generateDiscoveryBriefing` (Task 2 Step 4) does not — it follows the simpler, more recent precedent set by `family-audit.ts`'s `generateFamilyAuditContent`, which also skips the bilingual family-context block and Polish localisation entirely. Both AI surfaces are now consistent with each other; only the original weekly per-child briefing does full EN/PL family-context injection. This is called out here rather than silently diverging from the written spec.
+- **Placeholder scan:** No TBD/TODO. Both D1-bound tasks (2) are verified via typecheck + manual dev-server check rather than a red/green D1 unit test, consistent with the balance-math-shared-fix plan's justification (no D1 test harness exists in this repo).
+- **Type consistency:** `DiscoveryBriefingContent` (`{ intro: string; actions: string[] }`) is defined once in Task 1 and reused unchanged through Task 2 (route) and Task 3 (frontend, inlined as a matching object-literal type since the frontend doesn't import worker types). `DiscoveryCandidateKey`'s three string-literal values match exactly between Task 1's `getOutstandingCandidates`/`CANDIDATE_TEXT` and Task 2's system-prompt documentation of the same three keys.

--- a/docs/superpowers/plans/2026-07-07-family-audit.md
+++ b/docs/superpowers/plans/2026-07-07-family-audit.md
@@ -1,0 +1,1213 @@
+# Family Audit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a monthly, family-wide AI spending/earning/saving rollup for parents (Phase 5 "Audit" roadmap item), and standardize the EU AI Act Article 50 "AI-generated" disclosure across every AI-authored card in the app.
+
+**Architecture:** New D1 table `family_audit_snapshots` caches one row per family per calendar month. A new worker route `GET /api/family-audit` aggregates ledger/spending/jar_movements/give_requests data across all children in the family, picks a "flagged" child via a Pillar-priority ladder (mirrors the existing per-child weekly briefing logic), calls `gpt-4o-mini` for narrative text with a rule-based fallback on error/timeout, and caches the result. A new `FamilyAuditCard` React component renders it in the parent Insights tab. A shared `AiDisclosurePill` component (extracted from existing inline JSX) is reused on the new card and retrofitted onto the existing child-facing nudge banner.
+
+**Tech Stack:** Cloudflare Workers (TypeScript) + D1 (SQLite), React 18 + Vite + TypeScript, Vitest + React Testing Library, OpenAI `gpt-4o-mini` via raw `fetch`.
+
+## Global Constraints
+
+- Never use `wrangler d1` with `--local` — local D1 is dead per project rules.
+- Migrations are applied to `morechard-dev` first (no `--env` flag), verified, then to `morechard` with `--env production`.
+- All monetary values are stored and transmitted as integer pence.
+- UK English spelling throughout any user-facing copy ("Wellbeing", "Organise", etc.).
+- First-person plural ("We", "Us", "Our") in all AI/coaching-voice copy.
+- Every AI-generated (not rule-based-fallback) card must show the "AI-generated" disclosure pill (EU AI Act Article 50).
+- `has_ai_mentor` / plan gating is NOT applied to this feature — it follows the existing Insights tab precedent of being always-visible (see `mentor_briefing` in `insights.ts`, which has no plan gate).
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `worker/migrations/0076_family_audit_snapshots.sql` | New cache table |
+| `worker/src/lib/familyAudit.ts` | Pure, unit-testable logic: month-key helpers, flagged-child picker, rule-based text generator |
+| `worker/src/routes/family-audit.ts` | `GET /api/family-audit` handler — DB aggregation, cache read/write, LLM call |
+| `worker/src/index.ts` | Route registration (modify) |
+| `app/src/components/ui/PremiumShell.tsx` | Add `AiDisclosurePill` export (modify) |
+| `app/src/lib/api.ts` | Add `FamilyAuditData` type + `getFamilyAudit()` client (modify) |
+| `app/src/components/dashboard/FamilyAuditCard.tsx` | New card component |
+| `app/src/components/dashboard/InsightsTab.tsx` | Mount `FamilyAuditCard`; refactor inline pill to use `AiDisclosurePill` (modify) |
+| `app/src/components/child/ChildNudgeBanner.tsx` | Retrofit disclosure to use `AiDisclosurePill` (modify) |
+| `worker/src/lib/familyAudit.test.ts` | Unit tests for pure logic |
+| `app/src/components/ui/__tests__/PremiumShell.test.tsx` | Unit test for `AiDisclosurePill` |
+| `app/src/components/dashboard/__tests__/FamilyAuditCard.test.tsx` | Component test |
+| `app/src/components/child/__tests__/ChildNudgeBanner.test.tsx` | Component test |
+
+---
+
+### Task 1: D1 migration for `family_audit_snapshots`
+
+**Files:**
+- Create: `worker/migrations/0076_family_audit_snapshots.sql`
+
+**Interfaces:**
+- Produces: table `family_audit_snapshots` with columns `family_id, month_key, total_earned_pence, total_spent_pence, total_saved_pence, total_given_pence, flagged_child_id, flagged_pillar, observation, behavioral_root, the_action, source, created_at`, unique on `(family_id, month_key)`.
+
+- [ ] **Step 1: Write the migration file**
+
+```sql
+-- 0076_family_audit_snapshots.sql
+-- Monthly, family-wide AI spending/earning/saving rollup — cache-on-read,
+-- one row per family per calendar month (mirrors insight_snapshots).
+
+CREATE TABLE IF NOT EXISTS family_audit_snapshots (
+  id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+  family_id           TEXT NOT NULL REFERENCES families(id),
+  month_key           TEXT NOT NULL,  -- 'YYYY-MM'
+  total_earned_pence  INTEGER NOT NULL DEFAULT 0,
+  total_spent_pence   INTEGER NOT NULL DEFAULT 0,
+  total_saved_pence   INTEGER NOT NULL DEFAULT 0,
+  total_given_pence   INTEGER NOT NULL DEFAULT 0,
+  flagged_child_id    TEXT REFERENCES users(id),
+  flagged_pillar      TEXT,
+  observation         TEXT,
+  behavioral_root     TEXT,
+  the_action          TEXT,
+  source              TEXT NOT NULL DEFAULT 'rule_based' CHECK (source IN ('rule_based','ai')),
+  created_at          INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_family_audit_month
+  ON family_audit_snapshots (family_id, month_key);
+```
+
+- [ ] **Step 2: Apply to morechard-dev**
+
+Run (from `worker/`):
+```bash
+npx wrangler d1 migrations apply morechard-dev --remote
+```
+Expected: output lists `0076_family_audit_snapshots.sql` as applied, no errors.
+
+- [ ] **Step 3: Verify the table exists**
+
+Run:
+```bash
+npx wrangler d1 execute morechard-dev --remote --command="SELECT sql FROM sqlite_master WHERE name='family_audit_snapshots'"
+```
+Expected: one row showing the `CREATE TABLE` statement.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add worker/migrations/0076_family_audit_snapshots.sql
+git commit -m "feat: add family_audit_snapshots migration"
+```
+
+---
+
+### Task 2: Shared `AiDisclosurePill` component + refactor existing usage
+
+**Files:**
+- Modify: `app/src/components/ui/PremiumShell.tsx`
+- Modify: `app/src/components/dashboard/InsightsTab.tsx:20,540-546`
+- Test: `app/src/components/ui/__tests__/PremiumShell.test.tsx`
+
+**Interfaces:**
+- Produces: `AiDisclosurePill(): JSX.Element` exported from `PremiumShell.tsx` — no props.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// app/src/components/ui/__tests__/PremiumShell.test.tsx
+import { render, screen } from '@testing-library/react'
+import { AiDisclosurePill } from '../PremiumShell'
+import { describe, it, expect } from 'vitest'
+
+describe('AiDisclosurePill', () => {
+  it('renders the AI-generated disclosure text', () => {
+    render(<AiDisclosurePill />)
+    expect(screen.getByText('AI-generated')).toBeTruthy()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd app && npx vitest run src/components/ui/__tests__/PremiumShell.test.tsx`
+Expected: FAIL — `AiDisclosurePill` is not exported from `../PremiumShell`.
+
+- [ ] **Step 3: Add the component to PremiumShell.tsx**
+
+Add after the existing `ProBadge` export in `app/src/components/ui/PremiumShell.tsx`:
+
+```tsx
+/**
+ * EU AI Act Article 50 disclosure — shown on every card whose content is
+ * genuinely AI-generated (never on deterministic rule-based fallback text).
+ */
+export function AiDisclosurePill() {
+  return (
+    <span
+      className="text-[9px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded-full"
+      style={{
+        background: 'rgba(255,255,255,0.08)',
+        color:      'rgba(164,196,181,0.85)',
+        border:     '1px solid rgba(255,255,255,0.1)',
+      }}
+    >
+      AI-generated
+    </span>
+  )
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd app && npx vitest run src/components/ui/__tests__/PremiumShell.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Refactor InsightsTab.tsx to use the shared component**
+
+In `app/src/components/dashboard/InsightsTab.tsx`, change the import on line 20:
+
+```tsx
+import { PremiumShell, MentorAvatar, ProBadge, injectPremiumStyles } from '../ui/PremiumShell'
+```
+to:
+```tsx
+import { PremiumShell, MentorAvatar, ProBadge, AiDisclosurePill, injectPremiumStyles } from '../ui/PremiumShell'
+```
+
+Then replace the inline pill block (lines 540-546):
+
+```tsx
+                  {/* EU AI Act Article 50 disclosure — visible on every AI-generated card */}
+                  {briefing.source !== 'fallback' && (
+                    <span className="text-[9px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded-full"
+                          style={{ background: 'rgba(255,255,255,0.08)', color: 'rgba(164,196,181,0.85)', border: '1px solid rgba(255,255,255,0.1)' }}>
+                      AI-generated
+                    </span>
+                  )}
+```
+with:
+```tsx
+                  {/* EU AI Act Article 50 disclosure — visible on every AI-generated card */}
+                  {briefing.source !== 'fallback' && <AiDisclosurePill />}
+```
+
+- [ ] **Step 6: Run the full frontend test suite to confirm no regression**
+
+Run: `cd app && npx vitest run`
+Expected: all existing tests still PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/src/components/ui/PremiumShell.tsx app/src/components/dashboard/InsightsTab.tsx app/src/components/ui/__tests__/PremiumShell.test.tsx
+git commit -m "refactor: extract shared AiDisclosurePill component"
+```
+
+---
+
+### Task 3: Pure logic — month keys, flagged-child picker, rule-based text
+
+**Files:**
+- Create: `worker/src/lib/familyAudit.ts`
+- Test: `worker/src/lib/familyAudit.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `getMonthKey(date: Date): string` — e.g. `'2026-07'`
+  - `getMonthStartEpoch(monthKey: string): number` — UTC seconds
+  - `interface ChildMonthSignal { child_id: string; child_name: string; available_balance_pence: number; goals_locked_pence: number; planning_horizon: number | null; responsibility_score: number | null }`
+  - `interface FlaggedChild { child_id: string; child_name: string; pillar: FlaggedPillar }`
+  - `type FlaggedPillar = 'PILLAR_5_SOCIAL_RESPONSIBILITY' | 'PILLAR_3_OPPORTUNITY_COST' | 'PILLAR_1_LABOUR_VALUE' | 'PILLAR_4_CAPITAL_MANAGEMENT'`
+  - `pickFlaggedChild(signals: ChildMonthSignal[]): FlaggedChild | null`
+  - `interface FamilyTotals { total_earned_pence: number; total_spent_pence: number; total_saved_pence: number; total_given_pence: number }`
+  - `interface FamilyAuditContent { observation: string; behavioral_root: string; the_action: string }`
+  - `buildRuleBasedFamilyAudit(totals: FamilyTotals, flagged: FlaggedChild, familyName: string): FamilyAuditContent`
+- Consumed by: Task 4 (`family-audit.ts`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// worker/src/lib/familyAudit.test.ts
+import { describe, it, expect } from 'vitest';
+import {
+  getMonthKey, getMonthStartEpoch, pickFlaggedChild, buildRuleBasedFamilyAudit,
+  type ChildMonthSignal,
+} from './familyAudit.js';
+
+describe('getMonthKey', () => {
+  it('formats a July 2026 date as 2026-07', () => {
+    expect(getMonthKey(new Date(Date.UTC(2026, 6, 7)))).toBe('2026-07');
+  });
+  it('pads single-digit months', () => {
+    expect(getMonthKey(new Date(Date.UTC(2026, 0, 15)))).toBe('2026-01');
+  });
+});
+
+describe('getMonthStartEpoch', () => {
+  it('returns the UTC epoch seconds for the 1st of the given month', () => {
+    const expected = Math.floor(Date.UTC(2026, 6, 1) / 1000);
+    expect(getMonthStartEpoch('2026-07')).toBe(expected);
+  });
+});
+
+describe('pickFlaggedChild', () => {
+  const base: ChildMonthSignal = {
+    child_id: 'c1', child_name: 'Logan',
+    available_balance_pence: 0, goals_locked_pence: 0,
+    planning_horizon: 50, responsibility_score: 90,
+  };
+
+  it('returns null for an empty signal list', () => {
+    expect(pickFlaggedChild([])).toBeNull();
+  });
+
+  it('prioritises Pillar 5 when a child has a surplus balance over £100', () => {
+    const signals = [base, { ...base, child_id: 'c2', child_name: 'Mia', available_balance_pence: 10001 }];
+    const result = pickFlaggedChild(signals);
+    expect(result).toEqual({ child_id: 'c2', child_name: 'Mia', pillar: 'PILLAR_5_SOCIAL_RESPONSIBILITY' });
+  });
+
+  it('falls to Pillar 3 when planning horizon is low and no surplus exists', () => {
+    const signals = [base, { ...base, child_id: 'c2', child_name: 'Mia', planning_horizon: 10 }];
+    const result = pickFlaggedChild(signals);
+    expect(result).toEqual({ child_id: 'c2', child_name: 'Mia', pillar: 'PILLAR_3_OPPORTUNITY_COST' });
+  });
+
+  it('falls to Pillar 1 when responsibility score is low', () => {
+    const signals = [base, { ...base, child_id: 'c2', child_name: 'Mia', responsibility_score: 40 }];
+    const result = pickFlaggedChild(signals);
+    expect(result).toEqual({ child_id: 'c2', child_name: 'Mia', pillar: 'PILLAR_1_LABOUR_VALUE' });
+  });
+
+  it('defaults to Pillar 4, picking the highest planning horizon, when no other signal fires', () => {
+    const signals = [base, { ...base, child_id: 'c2', child_name: 'Mia', planning_horizon: 80 }];
+    const result = pickFlaggedChild(signals);
+    expect(result).toEqual({ child_id: 'c2', child_name: 'Mia', pillar: 'PILLAR_4_CAPITAL_MANAGEMENT' });
+  });
+
+  it('treats a single child as its own subject with no comparison', () => {
+    const result = pickFlaggedChild([base]);
+    expect(result?.child_id).toBe('c1');
+  });
+});
+
+describe('buildRuleBasedFamilyAudit', () => {
+  const totals = { total_earned_pence: 5000, total_spent_pence: 2000, total_saved_pence: 1500, total_given_pence: 500 };
+
+  it('names the correct Pillar for each flagged pillar type', () => {
+    const cases: Array<[ChildMonthSignal['planning_horizon'] extends never ? never : string, string]> = [] as never;
+    const pillars = ['PILLAR_5_SOCIAL_RESPONSIBILITY', 'PILLAR_3_OPPORTUNITY_COST', 'PILLAR_1_LABOUR_VALUE', 'PILLAR_4_CAPITAL_MANAGEMENT'] as const;
+    for (const pillar of pillars) {
+      const content = buildRuleBasedFamilyAudit(totals, { child_id: 'c1', child_name: 'Logan', pillar }, 'Thomson');
+      expect(content.behavioral_root).toContain(
+        pillar === 'PILLAR_5_SOCIAL_RESPONSIBILITY' ? 'Pillar 5' :
+        pillar === 'PILLAR_3_OPPORTUNITY_COST'      ? 'Pillar 3' :
+        pillar === 'PILLAR_1_LABOUR_VALUE'          ? 'Pillar 1' : 'Pillar 4'
+      );
+      expect(content.observation).toContain('Logan') ;
+      expect(content.the_action.length).toBeGreaterThan(0);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd worker && npx vitest run src/lib/familyAudit.test.ts`
+Expected: FAIL — `./familyAudit.js` does not exist.
+
+- [ ] **Step 3: Implement `familyAudit.ts`**
+
+```ts
+// worker/src/lib/familyAudit.ts
+//
+// Pure, DB-free logic for the monthly Family Audit (Phase 5). Kept separate
+// from the route handler so the flagged-child priority ladder and the
+// rule-based fallback text can be unit tested without a D1 binding.
+
+export function getMonthKey(date: Date): string {
+  const y = date.getUTCFullYear();
+  const m = String(date.getUTCMonth() + 1).padStart(2, '0');
+  return `${y}-${m}`;
+}
+
+export function getMonthStartEpoch(monthKey: string): number {
+  const [y, m] = monthKey.split('-').map(Number);
+  return Math.floor(Date.UTC(y, m - 1, 1) / 1000);
+}
+
+export interface ChildMonthSignal {
+  child_id: string;
+  child_name: string;
+  available_balance_pence: number;
+  goals_locked_pence: number;
+  planning_horizon: number | null;      // 0–100 | null (no goals/balance yet)
+  responsibility_score: number | null;  // first-time pass rate, 0–100 | null
+}
+
+export type FlaggedPillar =
+  | 'PILLAR_5_SOCIAL_RESPONSIBILITY'
+  | 'PILLAR_3_OPPORTUNITY_COST'
+  | 'PILLAR_1_LABOUR_VALUE'
+  | 'PILLAR_4_CAPITAL_MANAGEMENT';
+
+export interface FlaggedChild {
+  child_id:   string;
+  child_name: string;
+  pillar:     FlaggedPillar;
+}
+
+/**
+ * Picks the one child whose pattern most needs a parent's attention this
+ * month, using the same Pillar-priority ladder as the per-child weekly
+ * briefing's buildRuleBasedBriefing (insights.ts): surplus/Pillar 5 first,
+ * then opportunity cost, then labour value, defaulting to capital
+ * management (the best performer) when nothing else fires.
+ */
+export function pickFlaggedChild(signals: ChildMonthSignal[]): FlaggedChild | null {
+  if (signals.length === 0) return null;
+
+  const surplus = signals.find(s =>
+    s.available_balance_pence > 10000 ||
+    (s.goals_locked_pence === 0 && s.available_balance_pence > 0)
+  );
+  if (surplus) {
+    return { child_id: surplus.child_id, child_name: surplus.child_name, pillar: 'PILLAR_5_SOCIAL_RESPONSIBILITY' };
+  }
+
+  const spendHeavy = signals.find(s => (s.planning_horizon ?? 50) < 20);
+  if (spendHeavy) {
+    return { child_id: spendHeavy.child_id, child_name: spendHeavy.child_name, pillar: 'PILLAR_3_OPPORTUNITY_COST' };
+  }
+
+  const struggling = signals.find(s => (s.responsibility_score ?? 100) < 60);
+  if (struggling) {
+    return { child_id: struggling.child_id, child_name: struggling.child_name, pillar: 'PILLAR_1_LABOUR_VALUE' };
+  }
+
+  const best = [...signals].sort((a, b) => (b.planning_horizon ?? 0) - (a.planning_horizon ?? 0))[0];
+  return { child_id: best.child_id, child_name: best.child_name, pillar: 'PILLAR_4_CAPITAL_MANAGEMENT' };
+}
+
+export interface FamilyTotals {
+  total_earned_pence: number;
+  total_spent_pence:  number;
+  total_saved_pence:  number;
+  total_given_pence:  number;
+}
+
+export interface FamilyAuditContent {
+  observation:     string;
+  behavioral_root: string;
+  the_action:      string;
+}
+
+/** Deterministic fallback text — used when the LLM call errors or times out. */
+export function buildRuleBasedFamilyAudit(
+  totals:      FamilyTotals,
+  flagged:     FlaggedChild,
+  familyName:  string,
+): FamilyAuditContent {
+  const earnedDisplay = `£${(totals.total_earned_pence / 100).toFixed(2)}`;
+  const spentDisplay  = `£${(totals.total_spent_pence  / 100).toFixed(2)}`;
+
+  switch (flagged.pillar) {
+    case 'PILLAR_5_SOCIAL_RESPONSIBILITY':
+      return {
+        observation:     `We've noted that the ${familyName} family earned ${earnedDisplay} this month, and ${flagged.child_name} is carrying a meaningful surplus balance.`,
+        behavioral_root: 'Pillar 5 — Social Responsibility: a funded surplus without a social allocation represents idle capital in behavioural finance terms.',
+        the_action:      `You might consider introducing a Social Allocation target for ${flagged.child_name} (e.g. 5–10% of surplus) this month.`,
+      };
+    case 'PILLAR_3_OPPORTUNITY_COST':
+      return {
+        observation:     `We've noted that ${flagged.child_name}'s Planning Horizon is low this month, with ${spentDisplay} spent across the family overall.`,
+        behavioral_root: 'Pillar 3 — Opportunity Cost: a low Planning Horizon at this stage indicates a preference for immediate value over compounding future returns.',
+        the_action:      `You might consider asking ${flagged.child_name} what goal one recent purchase could have moved forward instead.`,
+      };
+    case 'PILLAR_1_LABOUR_VALUE':
+      return {
+        observation:     `We've noted a dip in task consistency or first-time pass rate for ${flagged.child_name} this month.`,
+        behavioral_root: 'Pillar 1 — Labour Value: variable-quality weeks are part of every growth cycle; the productive question is whether the cause is task scope, motivation, or reward structure.',
+        the_action:      `You might consider a short check-in with ${flagged.child_name} about which tasks feel hardest right now.`,
+      };
+    case 'PILLAR_4_CAPITAL_MANAGEMENT':
+    default:
+      return {
+        observation:     `We've noted a stable month for the ${familyName} family — ${earnedDisplay} earned in total, with ${flagged.child_name} showing the strongest Planning Horizon.`,
+        behavioral_root: 'Pillar 4 — Capital Management: sustained stability at high performance is the optimal condition for introducing compound growth concepts.',
+        the_action:      `You might consider modelling with ${flagged.child_name} what a 5% annual return would look like on their current savings balance.`,
+      };
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd worker && npx vitest run src/lib/familyAudit.test.ts`
+Expected: PASS (all cases)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add worker/src/lib/familyAudit.ts worker/src/lib/familyAudit.test.ts
+git commit -m "feat: add pure family-audit logic (month keys, flagged-child picker, rule-based fallback)"
+```
+
+---
+
+### Task 4: `GET /api/family-audit` route handler
+
+**Files:**
+- Create: `worker/src/routes/family-audit.ts`
+- Modify: `worker/src/index.ts`
+
+**Interfaces:**
+- Consumes: `getMonthKey`, `getMonthStartEpoch`, `pickFlaggedChild`, `buildRuleBasedFamilyAudit`, `ChildMonthSignal`, `FamilyTotals`, `FlaggedChild` from `../lib/familyAudit.js` (Task 3); `getFamilyContext` from `../lib/intelligence.js`; `captureAiGeneration` from `../lib/posthog.js`; `json`, `error` from `../lib/response.js`; `JwtPayload` from `../lib/jwt.js`; `Env` from `../types.js`.
+- Produces: `handleGetFamilyAudit(request: Request, env: Env): Promise<Response>`, registered at `GET /api/family-audit`.
+
+- [ ] **Step 1: Implement the route handler**
+
+```ts
+// worker/src/routes/family-audit.ts
+//
+// GET /api/family-audit?family_id=
+//
+// Monthly, family-wide spending/earning/saving rollup for parents.
+// Cached one row per family per calendar month in family_audit_snapshots —
+// on cache miss, calls gpt-4o-mini for narrative text (with a rule-based
+// fallback on error/timeout), mirroring the per-child weekly briefing
+// pattern in insights.ts.
+
+import type { Env } from '../types.js';
+import { json, error } from '../lib/response.js';
+import { JwtPayload } from '../lib/jwt.js';
+import { captureAiGeneration } from '../lib/posthog.js';
+import { getFamilyContext } from '../lib/intelligence.js';
+import {
+  getMonthKey, getMonthStartEpoch, pickFlaggedChild, buildRuleBasedFamilyAudit,
+  ChildMonthSignal, FamilyTotals, FlaggedChild,
+} from '../lib/familyAudit.js';
+
+type AuthedRequest = Request & { auth: JwtPayload };
+
+export async function handleGetFamilyAudit(request: Request, env: Env): Promise<Response> {
+  const auth      = (request as AuthedRequest).auth;
+  const family_id = new URL(request.url).searchParams.get('family_id');
+
+  if (!family_id) return error('family_id required');
+  if (family_id !== auth.family_id) return error('Forbidden', 403);
+  if (auth.role === 'child') return error('Forbidden', 403);
+
+  const monthKey   = getMonthKey(new Date());
+  const monthStart = getMonthStartEpoch(monthKey);
+
+  const cached = await env.DB.prepare(`
+    SELECT total_earned_pence, total_spent_pence, total_saved_pence, total_given_pence,
+           flagged_child_id, flagged_pillar, observation, behavioral_root, the_action, source
+    FROM family_audit_snapshots WHERE family_id = ? AND month_key = ?
+  `).bind(family_id, monthKey).first<{
+    total_earned_pence: number; total_spent_pence: number; total_saved_pence: number; total_given_pence: number;
+    flagged_child_id: string; flagged_pillar: string;
+    observation: string; behavioral_root: string; the_action: string; source: 'rule_based' | 'ai';
+  }>();
+
+  if (cached) {
+    return json({
+      month: monthKey,
+      totals: {
+        total_earned_pence: cached.total_earned_pence,
+        total_spent_pence:  cached.total_spent_pence,
+        total_saved_pence:  cached.total_saved_pence,
+        total_given_pence:  cached.total_given_pence,
+      },
+      flagged_child_id: cached.flagged_child_id,
+      flagged_pillar:   cached.flagged_pillar,
+      observation:      cached.observation,
+      behavioral_root:  cached.behavioral_root,
+      the_action:       cached.the_action,
+      source:           cached.source,
+    });
+  }
+
+  const familyCtx = await getFamilyContext(env.DB, family_id);
+  if (familyCtx.child_ids.length === 0) return json({ month: monthKey, is_empty: true });
+
+  const placeholders = familyCtx.child_ids.map(() => '?').join(',');
+
+  const [earnedRow, spentRow, savedRow, givenRow] = await Promise.all([
+    env.DB.prepare(`
+      SELECT COALESCE(SUM(amount),0) AS total FROM ledger
+      WHERE family_id=? AND entry_type='credit' AND created_at >= ? AND child_id IN (${placeholders})
+    `).bind(family_id, monthStart, ...familyCtx.child_ids).first<{ total: number }>(),
+
+    env.DB.prepare(`
+      SELECT COALESCE(SUM(amount),0) AS total FROM spending
+      WHERE family_id=? AND spent_at >= ? AND child_id IN (${placeholders})
+    `).bind(family_id, monthStart, ...familyCtx.child_ids).first<{ total: number }>(),
+
+    env.DB.prepare(`
+      SELECT COALESCE(SUM(delta),0) AS total FROM jar_movements
+      WHERE family_id=? AND jar='save' AND kind='allocation' AND created_at >= ? AND child_id IN (${placeholders})
+    `).bind(family_id, monthStart, ...familyCtx.child_ids).first<{ total: number }>(),
+
+    env.DB.prepare(`
+      SELECT COALESCE(SUM(amount),0) AS total FROM give_requests
+      WHERE family_id=? AND status='fulfilled' AND fulfilled_at >= ? AND child_id IN (${placeholders})
+    `).bind(family_id, monthStart, ...familyCtx.child_ids).first<{ total: number }>(),
+  ]);
+
+  const totals: FamilyTotals = {
+    total_earned_pence: earnedRow?.total ?? 0,
+    total_spent_pence:  spentRow?.total  ?? 0,
+    total_saved_pence:  savedRow?.total  ?? 0,
+    total_given_pence:  givenRow?.total  ?? 0,
+  };
+
+  if (totals.total_earned_pence === 0 && totals.total_spent_pence === 0) {
+    return json({ month: monthKey, is_empty: true });
+  }
+
+  const signals: ChildMonthSignal[] = [];
+  for (let i = 0; i < familyCtx.child_ids.length; i++) {
+    const childId   = familyCtx.child_ids[i];
+    const childName = familyCtx.child_names[i];
+
+    const [balRow, goalsRow, completionRow] = await Promise.all([
+      env.DB.prepare(`
+        SELECT COALESCE(SUM(CASE WHEN entry_type='credit' THEN amount ELSE -amount END),0) AS bal
+        FROM ledger WHERE family_id=? AND child_id=?
+      `).bind(family_id, childId).first<{ bal: number }>(),
+
+      env.DB.prepare(`
+        SELECT COALESCE(SUM(target_amount - current_saved_pence),0) AS locked
+        FROM goals WHERE family_id=? AND child_id=? AND archived=0 AND target_amount > current_saved_pence
+      `).bind(family_id, childId).first<{ locked: number }>().catch(() => ({ locked: 0 })),
+
+      env.DB.prepare(`
+        SELECT COUNT(*) AS total, SUM(CASE WHEN attempt_count=1 THEN 1 ELSE 0 END) AS first_time
+        FROM completions WHERE family_id=? AND child_id=? AND status='completed' AND resolved_at >= ?
+      `).bind(family_id, childId, monthStart).first<{ total: number; first_time: number }>(),
+    ]);
+
+    const availableBal    = Math.max(0, balRow?.bal ?? 0);
+    const goalsLocked     = goalsRow?.locked ?? 0;
+    const totalHeld       = availableBal + goalsLocked;
+    const totalCompleted  = completionRow?.total ?? 0;
+
+    signals.push({
+      child_id:                childId,
+      child_name:              childName,
+      available_balance_pence: availableBal,
+      goals_locked_pence:      goalsLocked,
+      planning_horizon:        totalHeld > 0 ? Math.round((goalsLocked / totalHeld) * 100) : null,
+      responsibility_score:    totalCompleted > 0 ? Math.round(((completionRow?.first_time ?? 0) / totalCompleted) * 100) : null,
+    });
+  }
+
+  const flagged = pickFlaggedChild(signals);
+  if (!flagged) return json({ month: monthKey, is_empty: true });
+
+  const content = await generateFamilyAuditContent(env, family_id, totals, flagged, familyCtx.family_name);
+
+  await env.DB.prepare(`
+    INSERT INTO family_audit_snapshots
+      (family_id, month_key, total_earned_pence, total_spent_pence, total_saved_pence, total_given_pence,
+       flagged_child_id, flagged_pillar, observation, behavioral_root, the_action, source)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).bind(
+    family_id, monthKey,
+    totals.total_earned_pence, totals.total_spent_pence, totals.total_saved_pence, totals.total_given_pence,
+    flagged.child_id, flagged.pillar,
+    content.observation, content.behavioral_root, content.the_action, content.source,
+  ).run();
+
+  return json({
+    month: monthKey,
+    totals,
+    flagged_child_id: flagged.child_id,
+    flagged_pillar:   flagged.pillar,
+    ...content,
+  });
+}
+
+interface GeneratedContent {
+  observation:     string;
+  behavioral_root: string;
+  the_action:      string;
+  source:          'ai' | 'rule_based';
+}
+
+async function generateFamilyAuditContent(
+  env:        Env,
+  familyId:   string,
+  totals:     FamilyTotals,
+  flagged:    FlaggedChild,
+  familyName: string,
+): Promise<GeneratedContent> {
+  const systemPrompt = `You are the 'Orchard Lead', a collaborative financial coach for parents. \
+Your goal is to analyse a family's month of financial behaviour data across ALL of their children \
+combined, and produce a professional family-wide executive briefing grounded in the Morechard \
+Financial Literacy Matrix.
+
+THE LITERACY MATRIX (your mandatory syllabus):
+- Pillar 1 — Labour Value ("The Toil"): Money is stored energy; link tasks to Purchasing Power.
+- Pillar 2 — Delayed Gratification ("The Season"): The wait for a bigger harvest; Needs vs. Wants.
+- Pillar 3 — Opportunity Cost ("Pruning the Path"): Every "Yes" to a small spend is a "No" to a major goal.
+- Pillar 4 — Capital Management ("The Savings Grove"): Compound Interest (Growth) and Inflation (Decay).
+- Pillar 5 — Social Responsibility ("The Overhang"): Using surplus harvest to contribute to the Community Forest.
+
+You have already been told which child and which Pillar to focus on — do not choose a different one.
+Reference the flagged child by name and ground the observation in the family totals provided.
+
+CONSTRAINTS:
+- Use first-person plural ("We", "Us", "Our") throughout.
+- Tone: supportive, egalitarian, collaborative. No chatbot fluff or excessive praise.
+- Choice Architecture: present options for the parent ("You might consider..."); never dictate.
+- UK English: "Wellbeing", "Pence", "Organise", "Behaviour", "Recognise".
+- behavioral_root MUST name the given Pillar explicitly.
+- Respond ONLY with a valid JSON object. No markdown, no commentary, no extra fields.
+
+Response schema (strict):
+{
+  "observation": "<1 sentence — a statement of fact based on the family totals and flagged child>",
+  "behavioral_root": "<1 sentence — names the given Pillar and links it to a future financial literacy outcome>",
+  "the_action": "<1 sentence — a concrete option for the parent, framed as a choice>"
+}`;
+
+  const userPrompt = JSON.stringify({
+    family_name:   familyName,
+    totals,
+    flagged_child: flagged.child_name,
+    flagged_pillar: flagged.pillar,
+  });
+
+  const messages = [
+    { role: 'system', content: systemPrompt },
+    { role: 'user',   content: userPrompt },
+  ];
+  const traceId = crypto.randomUUID();
+  const t0      = Date.now();
+
+  try {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type':  'application/json',
+        'Authorization': `Bearer ${env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model:           'gpt-4o-mini',
+        messages,
+        max_tokens:      350,
+        response_format: { type: 'json_object' },
+      }),
+      signal: AbortSignal.timeout(10000),
+    });
+
+    if (!res.ok) throw new Error(`OpenAI ${res.status}`);
+
+    const data   = await res.json() as { choices: Array<{ message: { content: string } }> };
+    const raw    = data.choices[0]?.message?.content ?? '';
+    const parsed = JSON.parse(raw) as Partial<GeneratedContent>;
+
+    if (!parsed.observation || !parsed.behavioral_root || !parsed.the_action) {
+      throw new Error('Incomplete AI response schema');
+    }
+
+    captureAiGeneration(env, {
+      distinctId:     familyId,
+      traceId,
+      spanName:       'family_audit',
+      model:          'gpt-4o-mini',
+      provider:       'openai',
+      input:          messages,
+      outputText:     raw,
+      latencySeconds: (Date.now() - t0) / 1000,
+    });
+
+    return { observation: parsed.observation, behavioral_root: parsed.behavioral_root, the_action: parsed.the_action, source: 'ai' };
+  } catch (err) {
+    captureAiGeneration(env, {
+      distinctId:     familyId,
+      traceId,
+      spanName:       'family_audit',
+      model:          'gpt-4o-mini',
+      provider:       'openai',
+      input:          messages,
+      latencySeconds: (Date.now() - t0) / 1000,
+      isError:        true,
+      errorMessage:   err instanceof Error ? err.message : String(err),
+    });
+
+    const fallback = buildRuleBasedFamilyAudit(totals, flagged, familyName);
+    return { ...fallback, source: 'rule_based' };
+  }
+}
+```
+
+- [ ] **Step 2: Register the route in `index.ts`**
+
+Add the import near the existing `child-nudges` import (around line 196):
+
+```ts
+import { handleGetFamilyAudit } from './routes/family-audit.js';
+```
+
+Add the route registration near the `/api/insights` line (around line 628):
+
+```ts
+  if (path === '/api/family-audit' && method === 'GET') return withAuth(request, auth, env, handleGetFamilyAudit);
+```
+
+- [ ] **Step 3: Type-check the worker**
+
+Run: `cd worker && npx tsc --noEmit`
+Expected: no new type errors.
+
+- [ ] **Step 4: Manual smoke test against morechard-dev**
+
+Run the worker locally against the remote dev DB (per `npm run dev` in repo root), then from another terminal:
+```bash
+curl -s "http://localhost:8787/api/family-audit?family_id=<a real dev family_id>" \
+  -H "Authorization: Bearer <a valid parent JWT from that family>"
+```
+Expected: JSON response with either `is_empty: true` (fresh/empty family) or a full `totals` + `observation`/`behavioral_root`/`the_action`/`source` payload.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add worker/src/routes/family-audit.ts worker/src/index.ts
+git commit -m "feat: add GET /api/family-audit route with LLM + rule-based fallback"
+```
+
+---
+
+### Task 5: Frontend API client
+
+**Files:**
+- Modify: `app/src/lib/api.ts`
+
+**Interfaces:**
+- Produces: `interface FamilyAuditData`, `getFamilyAudit(family_id: string): Promise<FamilyAuditData>`.
+- Consumed by: Task 6 (`FamilyAuditCard.tsx`).
+
+- [ ] **Step 1: Add the type and client function**
+
+Add near the existing `ChildNudge` types (after line 1323, the end of the child-nudges block) in `app/src/lib/api.ts`:
+
+```ts
+export interface FamilyAuditData {
+  month:             string;
+  is_empty?:         boolean;
+  totals?: {
+    total_earned_pence: number;
+    total_spent_pence:  number;
+    total_saved_pence:  number;
+    total_given_pence:  number;
+  };
+  flagged_child_id?:   string;
+  flagged_pillar?:     string;
+  observation?:        string;
+  behavioral_root?:    string;
+  the_action?:         string;
+  source?:             'ai' | 'rule_based';
+}
+
+export async function getFamilyAudit(family_id: string): Promise<FamilyAuditData> {
+  return request(`/api/family-audit?family_id=${family_id}`);
+}
+```
+
+- [ ] **Step 2: Type-check the frontend**
+
+Run: `cd app && npx tsc -b --noEmit`
+Expected: no new type errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/lib/api.ts
+git commit -m "feat: add getFamilyAudit API client function"
+```
+
+---
+
+### Task 6: `FamilyAuditCard` component + InsightsTab integration
+
+**Files:**
+- Create: `app/src/components/dashboard/FamilyAuditCard.tsx`
+- Modify: `app/src/components/dashboard/InsightsTab.tsx`
+- Test: `app/src/components/dashboard/__tests__/FamilyAuditCard.test.tsx`
+
+**Interfaces:**
+- Consumes: `getFamilyAudit`, `FamilyAuditData` from `../../lib/api.js` (Task 5); `PremiumShell`, `MentorAvatar`, `AiDisclosurePill`, `injectPremiumStyles` from `../ui/PremiumShell.js` (Task 2).
+- Produces: `FamilyAuditCard({ familyId: string }): JSX.Element | null`.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// app/src/components/dashboard/__tests__/FamilyAuditCard.test.tsx
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { FamilyAuditCard } from '../FamilyAuditCard'
+import * as api from '../../../lib/api'
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('FamilyAuditCard', () => {
+  it('renders totals and observation text when data is present', async () => {
+    vi.spyOn(api, 'getFamilyAudit').mockResolvedValue({
+      month: '2026-07',
+      totals: { total_earned_pence: 5000, total_spent_pence: 2000, total_saved_pence: 1500, total_given_pence: 500 },
+      flagged_child_id: 'c1',
+      flagged_pillar: 'PILLAR_4_CAPITAL_MANAGEMENT',
+      observation: 'We noted a stable month.',
+      behavioral_root: 'Pillar 4 — Capital Management: test root.',
+      the_action: 'You might consider a test action.',
+      source: 'ai',
+    })
+
+    render(<FamilyAuditCard familyId="fam1" />)
+
+    await waitFor(() => expect(screen.getByText('We noted a stable month.')).toBeTruthy())
+    expect(screen.getByText('£50.00')).toBeTruthy()
+    expect(screen.getByText('AI-generated')).toBeTruthy()
+  })
+
+  it('renders nothing when the family has no data yet this month', async () => {
+    vi.spyOn(api, 'getFamilyAudit').mockResolvedValue({ month: '2026-07', is_empty: true })
+
+    const { container } = render(<FamilyAuditCard familyId="fam1" />)
+
+    await waitFor(() => expect(container.firstChild).toBeNull())
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd app && npx vitest run src/components/dashboard/__tests__/FamilyAuditCard.test.tsx`
+Expected: FAIL — `../FamilyAuditCard` does not exist.
+
+- [ ] **Step 3: Implement `FamilyAuditCard.tsx`**
+
+```tsx
+// app/src/components/dashboard/FamilyAuditCard.tsx
+//
+// Monthly, family-wide AI rollup card — sits above the per-child Insights
+// dashboard. Fetched once per InsightsTab mount (family-scoped, not
+// re-fetched when the parent switches the selected child).
+
+import { useEffect, useState } from 'react'
+import { getFamilyAudit } from '../../lib/api'
+import type { FamilyAuditData } from '../../lib/api'
+import { PremiumShell, MentorAvatar, AiDisclosurePill, injectPremiumStyles } from '../ui/PremiumShell'
+
+interface Props {
+  familyId: string
+}
+
+const STAT_LABELS = [
+  { key: 'total_earned_pence', label: 'Earned' },
+  { key: 'total_spent_pence',  label: 'Spent'  },
+  { key: 'total_saved_pence',  label: 'Saved'  },
+  { key: 'total_given_pence',  label: 'Given'  },
+] as const
+
+function formatPence(pence: number): string {
+  return `£${(pence / 100).toFixed(2)}`
+}
+
+export function FamilyAuditCard({ familyId }: Props) {
+  const [data, setData]       = useState<FamilyAuditData | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => { injectPremiumStyles() }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    getFamilyAudit(familyId)
+      .then(d => { if (!cancelled) setData(d) })
+      .catch(() => { if (!cancelled) setData(null) })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [familyId])
+
+  if (loading || !data || data.is_empty || !data.totals) return null
+
+  return (
+    <PremiumShell>
+      <div className="px-4 pt-4 pb-3.5 relative z-10">
+
+        <div className="flex items-center gap-2 mb-3">
+          <MentorAvatar />
+          <span className="text-[10px] font-black uppercase tracking-wider" style={{ color: '#0d9488' }}>
+            This Month, Family-Wide
+          </span>
+          {data.source === 'ai' && <AiDisclosurePill />}
+        </div>
+
+        <div className="grid grid-cols-4 gap-2 mb-3.5">
+          {STAT_LABELS.map(({ key, label }) => (
+            <div key={key} className="text-center">
+              <p className="text-[13px] font-extrabold tabular-nums" style={{ color: '#f0fdf4' }}>
+                {formatPence(data.totals![key])}
+              </p>
+              <p className="text-[9px] uppercase tracking-wide" style={{ color: 'rgba(167,196,181,0.6)' }}>
+                {label}
+              </p>
+            </div>
+          ))}
+        </div>
+
+        <div className="space-y-1.5">
+          <p className="text-[13px] leading-relaxed" style={{ color: '#e2f5ee' }}>{data.observation}</p>
+          <p className="text-[12px] leading-relaxed" style={{ color: '#a7c4b5' }}>{data.behavioral_root}</p>
+          <p className="text-[12px] leading-relaxed font-semibold" style={{ color: '#6b9e87' }}>{data.the_action}</p>
+        </div>
+
+      </div>
+    </PremiumShell>
+  )
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd app && npx vitest run src/components/dashboard/__tests__/FamilyAuditCard.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Mount it in InsightsTab.tsx**
+
+In `app/src/components/dashboard/InsightsTab.tsx`, add the import near the other local component imports (after line 23, the `LabSection` import):
+
+```tsx
+import { FamilyAuditCard } from './FamilyAuditCard'
+```
+
+Then, in the `InsightsTab` root component's returned JSX (around line 71-100), add `<FamilyAuditCard familyId={familyId} />` as the first child, above the period toggle:
+
+```tsx
+  return (
+    <div className="space-y-4">
+
+      <FamilyAuditCard familyId={familyId} />
+
+      {/* ── Period toggle ── */}
+      <div className="flex gap-1.5 bg-[var(--color-surface-alt)] rounded-xl p-1">
+```
+
+- [ ] **Step 6: Run the full frontend test suite**
+
+Run: `cd app && npx vitest run`
+Expected: all tests PASS, including the two new `FamilyAuditCard` tests.
+
+- [ ] **Step 7: Manual verification in the browser**
+
+Start the dev server (`npm run dev` from repo root), sign in as a parent in a family with at least one completed chore and a ledger credit this month, open the Insights tab, and confirm the Family Audit card renders above the period toggle with the four stat totals and Problem→Insight→Action text.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/src/components/dashboard/FamilyAuditCard.tsx app/src/components/dashboard/InsightsTab.tsx app/src/components/dashboard/__tests__/FamilyAuditCard.test.tsx
+git commit -m "feat: add FamilyAuditCard to parent Insights tab"
+```
+
+---
+
+### Task 7: Retrofit `ChildNudgeBanner` disclosure to the shared pill
+
+**Files:**
+- Modify: `app/src/components/child/ChildNudgeBanner.tsx`
+- Test: `app/src/components/child/__tests__/ChildNudgeBanner.test.tsx`
+
+**Interfaces:**
+- Consumes: `AiDisclosurePill` from `../ui/PremiumShell.js` (Task 2).
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// app/src/components/child/__tests__/ChildNudgeBanner.test.tsx
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { ChildNudgeBanner } from '../ChildNudgeBanner'
+import type { ChildNudge } from '../../../lib/api'
+
+function makeNudge(source: ChildNudge['source']): ChildNudge {
+  return {
+    id: 1,
+    trigger_type: 'streak_3',
+    screen_context: 'earn',
+    orchard_text: 'Three tasks in a row!',
+    clean_text: 'Three-day streak.',
+    pillar: 'LABOR_VALUE',
+    tone: 'encouraging',
+    source,
+    parent_summary: 'Streak nudge',
+    created_at: 0,
+  }
+}
+
+describe('ChildNudgeBanner', () => {
+  it('shows the AI-generated pill when source is ai', () => {
+    render(<ChildNudgeBanner nudge={makeNudge('ai')} appView="ORCHARD" onDismiss={vi.fn()} />)
+    expect(screen.getByText('AI-generated')).toBeTruthy()
+  })
+
+  it('does not show the pill for rule_based nudges', () => {
+    render(<ChildNudgeBanner nudge={makeNudge('rule_based')} appView="ORCHARD" onDismiss={vi.fn()} />)
+    expect(screen.queryByText('AI-generated')).toBeNull()
+  })
+
+  it('still renders a static attribution footer regardless of source', () => {
+    render(<ChildNudgeBanner nudge={makeNudge('rule_based')} appView="ORCHARD" onDismiss={vi.fn()} />)
+    expect(screen.getByText(/Personalised coaching/)).toBeTruthy()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd app && npx vitest run src/components/child/__tests__/ChildNudgeBanner.test.tsx`
+Expected: FAIL — no element with text `AI-generated` for the `'ai'` case (current code only shows "AI coaching note" text, not the pill).
+
+- [ ] **Step 3: Update `ChildNudgeBanner.tsx`**
+
+Change the import (line 15):
+```tsx
+import { injectPremiumStyles, PremiumShell, MentorAvatar } from '../ui/PremiumShell'
+```
+to:
+```tsx
+import { injectPremiumStyles, PremiumShell, MentorAvatar, AiDisclosurePill } from '../ui/PremiumShell'
+```
+
+Replace the header block (lines 54-64):
+```tsx
+        {/* Header row */}
+        <div className="flex items-start gap-3 mb-3">
+          <MentorAvatar accent={accent} />
+          <div className="flex-1 min-w-0">
+            <p className="text-[10px] font-black uppercase tracking-wider" style={{ color: accent }}>
+              Your Orchard Mentor
+            </p>
+            <p className="text-[11px] mt-0.5" style={{ color: 'rgba(167,196,181,0.7)' }}>
+              {pillarLabel}
+            </p>
+          </div>
+```
+with:
+```tsx
+        {/* Header row */}
+        <div className="flex items-start gap-3 mb-3">
+          <MentorAvatar accent={accent} />
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-1.5">
+              <p className="text-[10px] font-black uppercase tracking-wider" style={{ color: accent }}>
+                Your Orchard Mentor
+              </p>
+              {nudge.source === 'ai' && <AiDisclosurePill />}
+            </div>
+            <p className="text-[11px] mt-0.5" style={{ color: 'rgba(167,196,181,0.7)' }}>
+              {pillarLabel}
+            </p>
+          </div>
+```
+
+Replace the attribution footer (lines 83-86):
+```tsx
+        {/* Attribution footer */}
+        <p className="text-[10px] mt-3 text-center" style={{ color: 'rgba(107,158,135,0.6)' }}>
+          ✦ Your Orchard Mentor · {nudge.source === 'ai' ? 'AI coaching note' : 'Personalised coaching'}
+        </p>
+```
+with:
+```tsx
+        {/* Attribution footer — the AI-generated distinction is now carried by the header pill above */}
+        <p className="text-[10px] mt-3 text-center" style={{ color: 'rgba(107,158,135,0.6)' }}>
+          ✦ Your Orchard Mentor · Personalised coaching
+        </p>
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd app && npx vitest run src/components/child/__tests__/ChildNudgeBanner.test.tsx`
+Expected: PASS (all three cases)
+
+- [ ] **Step 5: Run the full frontend test suite**
+
+Run: `cd app && npx vitest run`
+Expected: all tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/components/child/ChildNudgeBanner.tsx app/src/components/child/__tests__/ChildNudgeBanner.test.tsx
+git commit -m "fix: standardize AI disclosure pill on ChildNudgeBanner (EU AI Act Article 50)"
+```
+
+---
+
+### Task 8: Deploy migration + worker to production
+
+**Files:** none (operational task)
+
+This task touches the live production database and worker. Confirm with the
+user before running the `--env production` commands — do not run them
+unattended.
+
+- [ ] **Step 1: Apply the migration to production**
+
+Run (from `worker/`):
+```bash
+npx wrangler d1 migrations apply morechard --remote --env production
+```
+Expected: output lists `0076_family_audit_snapshots.sql` as applied.
+
+- [ ] **Step 2: Verify the table exists in production**
+
+Run:
+```bash
+npx wrangler d1 execute morechard --remote --env production --command="SELECT sql FROM sqlite_master WHERE name='family_audit_snapshots'"
+```
+Expected: one row showing the `CREATE TABLE` statement.
+
+- [ ] **Step 3: Deploy the worker**
+
+Run (from `worker/`):
+```bash
+npx wrangler deploy --env production
+```
+Expected: deploy succeeds, output shows the production worker URL.
+
+- [ ] **Step 4: Smoke-test the live endpoint**
+
+Run:
+```bash
+curl -s "https://<production-worker-url>/api/family-audit?family_id=<a real prod family_id>" \
+  -H "Authorization: Bearer <a valid parent JWT>"
+```
+Expected: JSON response (either `is_empty: true` or a full payload), no 500 errors.
+
+- [ ] **Step 5: Confirm the Cloudflare Pages frontend deploy**
+
+The frontend deploys automatically on push to `main` (per project convention — no manual step needed once Tasks 1-7 are pushed).
+
+- [ ] **Step 6: Update the roadmap in CLAUDE.md**
+
+In the repo root `CLAUDE.md`, under `### **Phase 5: The AI Mentor (Behavioral Nudging)**`, change:
+
+```diff
+- [ ] An AI-driven "Audit" of monthly spending across all children to identify family-wide trends
+- [ ] Linking "Seasonal" events (Birthdays, Holidays, School trips) to the Mentor's advice so it can predict future spending needs
++ [x] An AI-driven "Audit" of monthly spending across all children to identify family-wide trends — Family Audit card in parent Insights tab (`GET /api/family-audit`, `family_audit_snapshots` cache table)
+```
+
+(The "Seasonal events" line is removed entirely — dropped from scope, no DOB or events data exists to support it; see `docs/superpowers/specs/2026-07-07-family-audit-design.md` Context section.)
+
+Commit:
+```bash
+git add CLAUDE.md
+git commit -m "docs: mark Phase 5 Family Audit complete, drop out-of-scope seasonal events item"
+```

--- a/docs/superpowers/specs/2026-07-07-balance-math-shared-fix-design.md
+++ b/docs/superpowers/specs/2026-07-07-balance-math-shared-fix-design.md
@@ -1,0 +1,88 @@
+# Balance-Math Shared Fix — Design Spec
+
+**Date:** 2026-07-07
+**Status:** Approved for planning
+**Origin:** Follow-up noted during Family Audit build — `insights.ts` and
+`family-audit.ts` each compute a child's available balance with slightly
+different, independently buggy SQL.
+
+## Problem
+
+Both routes compute "available balance" for a child, but neither uses the
+canonical formula already established elsewhere in the codebase (`jars.ts`,
+`finance.ts` — see comment "same formula as GET /api/balance"):
+
+```sql
+SUM(CASE entry_type
+      WHEN 'credit'   THEN amount
+      WHEN 'reversal' THEN -amount
+      WHEN 'payment'  THEN -amount
+      ELSE 0 END)
+WHERE verification_status IN ('verified_auto','verified_manual')
+```
+
+- **`insights.ts:196-202`** (`available_balance_pence`): no `verification_status`
+  filter — pending, disputed, and reversed ledger entries all leak into the
+  balance. `CASE WHEN entry_type = 'credit' THEN amount ELSE -amount END`
+  also implicitly treats `system_note` as a debit, which is harmless today
+  (its amount is always inserted as 0) but is incidental, not intentional.
+- **`family-audit.ts:99-108`** (per-child `bal`, used to pick the flagged
+  child): has the `verification_status` filter, but its `CASE` only handles
+  `credit`/`payment` — `reversal` falls into `ELSE 0`, so a child who has had
+  a disputed entry reversed keeps the reversed credit counted, inflating
+  their balance and skewing which child gets flagged for the monthly audit.
+
+Both bugs affect real user-facing numbers: the KPI balance bar in Insights,
+and which child + Pillar the Family Audit surfaces to a parent.
+
+## Fix
+
+Add one shared helper, `worker/src/lib/ledgerBalance.ts`:
+
+```ts
+export async function getAvailableBalancePence(
+  db: D1Database, familyId: string, childId: string,
+): Promise<number> {
+  const row = await db.prepare(`
+    SELECT COALESCE(SUM(
+      CASE entry_type
+        WHEN 'credit'   THEN amount
+        WHEN 'reversal' THEN -amount
+        WHEN 'payment'  THEN -amount
+        ELSE 0
+      END
+    ), 0) AS bal
+    FROM ledger WHERE family_id = ? AND child_id = ?
+      AND verification_status IN ('verified_auto', 'verified_manual')
+  `).bind(familyId, childId).first<{ bal: number }>();
+  return row?.bal ?? 0;
+}
+```
+
+- `insights.ts` replaces its inline `balanceRow` query (lines 196-202) with a
+  call to `getAvailableBalancePence`.
+- `family-audit.ts` replaces its inline per-child `balRow` query (lines
+  99-108) with the same call.
+- Both routes keep `Math.max(0, ...)` at the call site where they already
+  clamp negative balances to 0 (unchanged behaviour, just fed a corrected
+  input).
+
+## Out of scope
+
+- `jars.ts` and `finance.ts` — already use the correct formula, not touched.
+- `total_earned_pence` / `lifetime_earned_pence` in `insights.ts` and
+  `total_earned_pence` in `family-audit.ts` — these are gross-earnings KPIs
+  (entry_type = 'credit' only, no verification_status filter), a different
+  metric from "available balance." Not part of this fix; not reported as
+  buggy.
+- Any change to `pickFlaggedChild`'s priority ladder logic itself — only the
+  `available_balance_pence` input it receives changes.
+
+## Testing
+
+- Unit test for `getAvailableBalancePence` isn't practical without a D1
+  binding (matches existing convention — `jar-balance.ts` has no direct
+  test either). Verify via `family-audit.test.ts`-style pure-logic tests
+  where feasible, and manual `wrangler d1 execute` spot-check against
+  `morechard-dev` post-deploy: a child with a `disputed`/`reversed` entry
+  should show a different (correct) balance before/after.

--- a/docs/superpowers/specs/2026-07-07-discovery-card-ai-design.md
+++ b/docs/superpowers/specs/2026-07-07-discovery-card-ai-design.md
@@ -1,0 +1,121 @@
+# Discovery Card AI Upgrade — Design Spec
+
+**Date:** 2026-07-07
+**Status:** Approved for planning
+**Origin:** Follow-up noted during Family Audit build — the parent Insights
+tab's `DiscoveryCard` (`InsightsTab.tsx:425-492`, shown while
+`is_discovery_phase`) is 100% static template text with only `{name}`
+interpolated. Every family sees the identical intro paragraph and the same
+hardcoded 3-step action list, even if they've already done some of it.
+
+## Goal
+
+Make the Discovery card genuinely AI-generated, in the same
+Orchard-Mentor / Problem-Insight-Action pattern as the weekly per-child
+briefing and the Family Audit — grounded in whatever *setup* signal exists
+before there's enough completion data for real behavioural coaching.
+
+## 1. What signal exists during Discovery Phase
+
+`is_discovery_phase` = `allTimeCompleted < 3 || daysSinceFirst < 7`. At this
+point there's no meaningful behavioural data, but there is real *setup*
+state, all queryable today:
+
+- Chore count assigned to the child (`chores` where `assigned_to = child_id`)
+- Whether any assigned chore has `proof_required = 1` (photo check-in)
+- Whether the child has an active goal (`goals` where `child_id = ? AND archived = 0`)
+- Whether jars are enabled (`jar_config.enabled`)
+- Family context (siblings, parenting mode) — for tone only, not gating
+
+## 2. Data & caching
+
+New migration `0077_discovery_briefings.sql`:
+
+```sql
+CREATE TABLE IF NOT EXISTS discovery_briefings (
+  child_id         TEXT PRIMARY KEY REFERENCES users(id),
+  family_id        TEXT NOT NULL REFERENCES families(id),
+  setup_signature  TEXT NOT NULL,
+  intro            TEXT NOT NULL,
+  actions          TEXT NOT NULL,   -- JSON array, up to 3: [{ "text": "..." }]
+  source           TEXT NOT NULL DEFAULT 'rule_based' CHECK (source IN ('rule_based','ai')),
+  created_at       INTEGER NOT NULL DEFAULT (unixepoch())
+);
+```
+
+One row per child. `setup_signature` is a short deterministic string built
+from the four setup facts above (e.g. bucketed chore count + 3 booleans),
+not a cryptographic hash — just enough to detect "something relevant
+changed."
+
+On every `GET /api/insights` call while `is_discovery_phase`:
+1. Query the four setup facts live (cheap, already-indexed lookups).
+2. Compute `setup_signature`.
+3. Read the cached `discovery_briefings` row for this child.
+   - **Match** → return cached `intro`/`actions`/`source` instantly.
+   - **Missing or signature differs** → regenerate (§3), `INSERT OR
+     REPLACE` the row, return the new content.
+
+This means the card updates itself the next time a parent opens Insights
+after adding a goal, turning on photo check-in, or assigning more chores —
+without polling or a background job.
+
+## 3. Generation
+
+New `worker/src/lib/discoveryBriefing.ts` (pure logic, mirrors
+`familyAudit.ts` — testable without a D1 binding):
+
+- A candidate action menu, each gated on whether it's already satisfied:
+  - `ASSIGN_MORE_CHORES` — fires when chore count < 3
+  - `SET_A_GOAL` — fires when no active goal exists
+  - `ENABLE_PHOTO_CHECKIN` — fires when no assigned chore has `proof_required = 1`
+- `buildRuleBasedDiscoveryBriefing()` — deterministic fallback: one sentence
+  per outstanding candidate (up to 3), or if none are outstanding, a single
+  "you're fully set up, I just need a few completions" message. This is also
+  what renders for a brand-new child with zero chores assigned (single
+  "assign chores" action, not padded to 3).
+
+`insights.ts` gets `generateDiscoveryBriefing()`, called only on cache
+miss/signature-change:
+- `gpt-4o-mini`, same Orchard Lead persona and Literacy-Matrix grounding as
+  the weekly briefing, JSON-strict response format, 10s timeout.
+- Prompt is given only the *outstanding* candidates (not the satisfied
+  ones) plus the family context block (reused from
+  `buildInsightsFamilyBlock`) and child name — so the model can't
+  accidentally suggest something already done.
+- Response schema: `{ "intro": "<1-2 sentences>", "actions": ["<up to 3
+  strings, one per outstanding candidate>"] }`.
+- Same `captureAiGeneration` tracing as the other two AI surfaces.
+- On error/timeout → `buildRuleBasedDiscoveryBriefing()`, `source: 'rule_based'`.
+
+## 4. Frontend
+
+`DiscoveryCard` (`InsightsTab.tsx`) reads `data.discovery_briefing.intro` and
+`.actions` instead of the two hardcoded paragraphs and fixed 3-item list.
+
+- `<AiDisclosurePill />` shown next to the "Orchard Mentor" label whenever
+  `source === 'ai'` — identical placement/condition to `LiveBriefingCard`
+  and the Family Audit card (EU AI Act Article 50 disclosure consistency,
+  per the Family Audit spec).
+- `DiscoveryAction` list renders 1–3 items from the array (today it always
+  renders exactly 3).
+- Progress ring (`{completed}/3`) and `ProBadge` are unchanged — they're
+  reading `all_time_completed`, not the briefing.
+
+## Edge cases
+
+- **Zero chores assigned, brand new child:** candidate menu is
+  `ASSIGN_MORE_CHORES` only → single-action card.
+- **Everything already configured** (≥3 chores, a goal, photo check-in on):
+  no candidates fire → intro-only message, no action list rendered.
+- **AI/network failure:** falls back to deterministic text per outstanding
+  candidate — never blocks the card from rendering.
+
+## Out of scope
+
+- Any change to the Discovery Phase *threshold* itself
+  (`allTimeCompleted < 3 || daysSinceFirst < 7`).
+- The progress ring / `all_time_completed` display — unchanged.
+- Regenerating mid-session (e.g. via websocket) when setup changes on
+  another device — the next `GET /api/insights` call picks it up, no push
+  mechanism.

--- a/docs/superpowers/specs/2026-07-07-family-audit-design.md
+++ b/docs/superpowers/specs/2026-07-07-family-audit-design.md
@@ -1,0 +1,150 @@
+# Family Audit — Design Spec
+
+**Date:** 2026-07-07
+**Status:** Approved for planning
+**Roadmap item:** Phase 5 — "An AI-driven 'Audit' of monthly spending across all children"
+
+## Context
+
+Phase 5 (AI Mentor / Behavioral Nudging) roadmap checkboxes for child-facing AI
+personality and spending-pattern nudges were already fully implemented (see
+`worker/src/routes/child-nudges.ts`, `ChildNudgeBanner.tsx`) — the roadmap was
+stale. The only two items genuinely remaining were:
+
+1. A monthly, family-wide spending "Audit" for parents.
+2. Linking seasonal events (birthdays, holidays, school trips) to Mentor advice.
+
+Item 2 is **dropped from scope**: Morechard does not collect child date of
+birth, and there is no events/calendar table anywhere in the schema, so a
+genuine "seasonal" feature would only ever be generic fixed-calendar nudges —
+judged too weak a version of the original idea to be worth building now.
+
+This spec covers item 1 only: the **Family Audit**.
+
+## Goal
+
+Give parents a once-a-month, family-wide rollup of spending/earning/saving
+behaviour across all their children, in the same Problem → Insight → Action
+format as the existing weekly per-child mentor briefing, surfaced in the
+parent Insights tab.
+
+## Compliance requirement (EU AI Act, effective 2026)
+
+Every AI-generated surface in the app must carry an explicit, visible
+disclosure that the content is AI-generated. This already exists as a
+precedent in `InsightsTab.tsx` (an "AI-generated" pill shown when
+`briefing.source !== 'fallback'`, explicitly commented as an EU AI Act
+Article 50 disclosure). This spec:
+
+- Applies the identical pill pattern to the new Family Audit card.
+- Additionally upgrades `ChildNudgeBanner.tsx`, which currently only discloses
+  via footer wording ("AI coaching note" vs "Personalised coaching"), to use
+  the same explicit pill component — bringing child-facing disclosure up to
+  the same visual standard as the parent-facing card.
+
+## 1. Data & schema
+
+New migration, `family_audit_snapshots` (mirrors `insight_snapshots`):
+
+```sql
+CREATE TABLE IF NOT EXISTS family_audit_snapshots (
+  id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+  family_id           TEXT NOT NULL REFERENCES families(id),
+  month_key           TEXT NOT NULL,  -- 'YYYY-MM'
+  total_earned_pence  INTEGER NOT NULL DEFAULT 0,
+  total_spent_pence   INTEGER NOT NULL DEFAULT 0,
+  total_saved_pence   INTEGER NOT NULL DEFAULT 0,
+  total_given_pence   INTEGER NOT NULL DEFAULT 0,
+  flagged_child_id    TEXT REFERENCES users(id),
+  flagged_pillar      TEXT,
+  observation         TEXT,   -- Problem
+  behavioral_root     TEXT,   -- Insight (names the Pillar)
+  the_action          TEXT,   -- Action (specific, parent-facing)
+  source              TEXT NOT NULL DEFAULT 'rule_based' CHECK (source IN ('rule_based','ai')),
+  created_at          INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_family_audit_month
+  ON family_audit_snapshots (family_id, month_key);
+```
+
+One row per family per calendar month. Cache-on-read, same convention as
+`insight_snapshots`.
+
+## 2. Backend: `GET /api/family-audit?family_id=`
+
+- Parent-only auth (403 for `role === 'child'` — matches the existing
+  sibling-privacy rule already enforced in the weekly briefing's family
+  context block).
+- `month_key` is always the current calendar month — no query param.
+- Aggregates, across every child in the family, for the month:
+  - `total_earned_pence` (ledger credits)
+  - `total_spent_pence` (spending table)
+  - `total_saved_pence` (goal_contributions)
+  - `total_given_pence` (jar_movements where jar = 'give')
+  - per-child consistency score / planning horizon, reusing the same SQL
+    shapes already in `insights.ts`
+- Picks the **flagged child**: run the same Pillar priority ladder used in
+  `buildRuleBasedBriefing` (Pillar 5 surplus → Pillar 3 opportunity cost →
+  Pillar 1 labour value → Pillar 2 delayed gratification → Pillar 4 default)
+  per child, independently; take whichever child matches the
+  highest-priority Pillar. With one child, that child is always the subject
+  — no cross-child comparison language is used in that case.
+- Cache check on `(family_id, month_key)`:
+  - **Hit** → return cached row instantly, `source` as stored.
+  - **Miss** → call `gpt-4o-mini` with a new system prompt (same We-voice,
+    same Pillar/Literacy-Matrix grounding, explicitly framed as family-wide
+    not per-child, same strict JSON schema), 10s timeout, same
+    `captureAiGeneration` tracing as the weekly briefing. On error/timeout,
+    fall back to a new `buildRuleBasedFamilyAudit()` deterministic generator
+    (same shape/tone as `buildRuleBasedBriefing`, scoped to the flagged
+    child + family totals). Persist whichever result to the cache row.
+
+## 3. Frontend
+
+New `FamilyAuditCard` component, rendered in `InsightsTab.tsx` above the
+existing per-child selector. Same `PremiumShell` / `MentorAvatar` /
+`ProBadge` visual system as the weekly card. Fetched once per `InsightsTab`
+mount (family-scoped, not re-fetched on child-selector change).
+
+Contents:
+- Header: "This Month, Family-Wide" + **AI-generated pill** (shown whenever
+  `source !== 'fallback' /* rule_based counts as non-disclosed since it's
+  deterministic template text, not model output */`).
+
+  Note: unlike the weekly briefing (which treats `cache` as still
+  AI-authored and shows the pill), this endpoint's `source` values are only
+  `'ai'` or `'rule_based'` — the pill shows for `'ai'` only.
+- Compact stat row: the four totals (earned/spent/saved/given) for the
+  month so far.
+- Problem → Insight → Action prose (`observation` / `behavioral_root` /
+  `the_action`), no section headers — matches existing card style.
+
+## 4. ChildNudgeBanner disclosure upgrade
+
+Replace the current footer wording-based disclosure:
+```
+✦ Your Orchard Mentor · {nudge.source === 'ai' ? 'AI coaching note' : 'Personalised coaching'}
+```
+with the same explicit pill component used in `LiveBriefingCard`
+(`InsightsTab.tsx`), shown in the header row next to the pillar label,
+visible whenever `nudge.source === 'ai'`. Since nearly all current nudges are
+`rule_based` (see `child-nudges.ts` — `generateChildNudge` always inserts
+`source = 'rule_based'`), the pill will rarely show today, but the mechanism
+is now in place and consistent for any future AI-authored nudge content.
+
+## 5. Edge cases
+
+- **Single-child family:** works unchanged — the "flagged child" is simply
+  that child, narrated without comparison language.
+- **No completions yet this month:** card doesn't render (same as
+  `mentor_briefing` being `null` during Discovery Phase).
+- **Family created mid-month:** aggregates are naturally smaller; no special
+  handling needed.
+
+## Out of scope
+
+- Seasonal event linking (birthdays/holidays/school trips) — dropped, see
+  Context above.
+- Any change to the existing weekly per-child briefing logic.
+- PDF/export tie-in (belongs to Phase 6 Legal Integrity Bundle).

--- a/docs/superpowers/specs/2026-07-07-insights-tab-layout-design.md
+++ b/docs/superpowers/specs/2026-07-07-insights-tab-layout-design.md
@@ -1,0 +1,97 @@
+# Insights Tab Layout Adjustments — Design Spec
+
+**Date:** 2026-07-07
+**Status:** Approved for planning
+**Context:** Follow-up to the Family Audit feature (see
+`2026-07-07-family-audit-design.md`). After manually verifying the new
+`FamilyAuditCard` in the browser, the user requested three layout
+adjustments to `app/src/components/dashboard/InsightsTab.tsx` before
+production deploy.
+
+## 1. Move the period toggle into the thumb zone
+
+**Problem:** The "This week / This month / All time" toggle currently sits
+at the top of the scrollable Insights content, above `FamilyAuditCard`. The
+app is mobile-first; frequently-tapped controls should sit at the bottom of
+the screen, reachable by thumb, matching every other primary action in the
+app.
+
+**Solution:** Reuse the exact fixed-positioning pattern already established
+by `JobsTab.tsx`'s "+ Add chore" button (`worker`-adjacent file
+`app/src/components/dashboard/JobsTab.tsx:391-401`):
+
+```tsx
+<div className="fixed bottom-0 inset-x-0 z-20 flex justify-center pointer-events-none">
+  <div
+    className="pointer-events-auto w-full max-w-[520px] mx-3"
+    style={{ marginBottom: 'calc(max(12px, env(safe-area-inset-bottom)) + 68px)' }}
+  >
+    {/* toggle content */}
+  </div>
+</div>
+```
+
+The period toggle's existing button markup (`InsightsTab.tsx:78-93`) moves
+inside this wrapper, replacing its current `<div className="flex gap-1.5 ...">`
+container. No new visibility logic is needed: this JSX stays inside
+`InsightsTab`, which is itself wrapped in a `tab-panel` div that becomes
+`display: none` when another bottom-nav tab is active (`index.css:289`) —
+a `display: none` ancestor hides `fixed` descendants too, so the toggle
+correctly disappears on other tabs without extra code.
+
+`z-20` matches `JobsTab`'s CTA (below the nav's own `z-30`), so if a future
+screen ever needs both patterns simultaneously they layer correctly.
+
+## 2. Group the two AI-generated cards together
+
+**Problem:** `FamilyAuditCard` (family-wide, monthly) sits at the very top
+of the tab. The per-child `MentorSection` card (weekly) currently renders
+after `BalanceBar` and the three `SparklineCard`s inside
+`InsightsDashboard` — separated from `FamilyAuditCard` by a full row of
+KPI cards.
+
+**Solution:** Reorder `InsightsDashboard`'s JSX
+(`InsightsTab.tsx:125-268`) so `MentorSection` renders immediately after
+the demo-account banner, ahead of `BalanceBar`. New order:
+
+1. Demo account banner (unchanged, conditional)
+2. `MentorSection` (moved up — was step 4)
+3. `BalanceBar` (was step 1)
+4. Sparkline cards grid (was step 2)
+5. Effort preference tag (was step 3)
+6. Child nudge summary (unchanged position, step 5)
+7. Learning Lab section (unchanged, step 6)
+8. Supporting stats (unchanged, step 7)
+
+`FamilyAuditCard` itself stays where it is, outside `InsightsDashboard`
+(rendered directly in `InsightsTab`'s return, above the loading/error/data
+branch) — it already sits immediately above where `InsightsDashboard`
+begins rendering, so this reorder is sufficient to put both AI cards
+back-to-back with nothing between them.
+
+## 3. Card dismissal
+
+Out of scope for this pass. Both cards already disappear on their own when
+there's no data (`FamilyAuditCard` returns `null` on `is_empty`;
+`MentorSection` shows a `DiscoveryCard` instead during the discovery
+phase, not a stale card) — there's no demonstrated staleness problem to
+solve yet. Revisit if real usage surfaces one.
+
+## Testing
+
+- `FamilyAuditCard.test.tsx` and any `InsightsTab` snapshot/render tests
+  are unaffected by content reordering (no test currently asserts DOM
+  order between `MentorSection` and `BalanceBar`) — confirm this remains
+  true after the change; add an order-assertion test only if one doesn't
+  already implicitly cover it.
+- No new component is introduced — this is a pure JSX reorder plus moving
+  existing markup into a differently-positioned wrapper `div`. No new
+  props, no new state.
+
+## Out of scope
+
+- Any change to `FamilyAuditCard`'s or `MentorSection`'s internal content
+  or styling.
+- Per-card dismiss UX (see §3).
+- Changes to `ParentBottomNav.tsx` itself — the nav bar is untouched; the
+  toggle is a sibling fixed element, not an addition to the nav component.

--- a/worker/migrations/0076_family_audit_snapshots.sql
+++ b/worker/migrations/0076_family_audit_snapshots.sql
@@ -1,0 +1,23 @@
+-- 0076_family_audit_snapshots.sql
+-- Monthly, family-wide AI spending/earning/saving rollup — cache-on-read,
+-- one row per family per calendar month (mirrors insight_snapshots).
+
+CREATE TABLE IF NOT EXISTS family_audit_snapshots (
+  id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+  family_id           TEXT NOT NULL REFERENCES families(id),
+  month_key           TEXT NOT NULL,  -- 'YYYY-MM'
+  total_earned_pence  INTEGER NOT NULL DEFAULT 0,
+  total_spent_pence   INTEGER NOT NULL DEFAULT 0,
+  total_saved_pence   INTEGER NOT NULL DEFAULT 0,
+  total_given_pence   INTEGER NOT NULL DEFAULT 0,
+  flagged_child_id    TEXT REFERENCES users(id),
+  flagged_pillar      TEXT,
+  observation         TEXT,
+  behavioral_root     TEXT,
+  the_action          TEXT,
+  source              TEXT NOT NULL DEFAULT 'rule_based' CHECK (source IN ('rule_based','ai')),
+  created_at          INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_family_audit_month
+  ON family_audit_snapshots (family_id, month_key);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -194,6 +194,7 @@ import { handleConsentPost, handleConsentGet, handleAnalyticsConsentPost, handle
 import { handlePublicInterest } from './routes/public-interest.js';
 import { handleGetJars, handlePutJarConfig, handlePostJarMove, handleGetJarMovements } from './routes/jars.js';
 import { handleGetChildNudges, handleDismissChildNudge, runChildNudgeBackgroundChecks } from './routes/child-nudges.js';
+import { handleGetFamilyAudit } from './routes/family-audit.js';
 import { handlePostGiveRequest, handleGetGiveRequests, handlePatchGiveRequest } from './routes/give-requests.js';
 import { json, error } from './lib/response.js';
 import { JwtPayload } from './lib/jwt.js';
@@ -626,6 +627,9 @@ async function route(request: Request, env: Env, method: string, path: string): 
 
   // Insights — parent or child (child sees own data only, enforced in handler)
   if (path === '/api/insights'  && method === 'GET')  return withAuth(request, auth, env, handleInsights);
+
+  // Family Audit — monthly family-wide rollup for parents (Phase 5)
+  if (path === '/api/family-audit' && method === 'GET') return withAuth(request, auth, env, handleGetFamilyAudit);
 
   // Child nudges — AI Mentor inline coaching cards
   if (path === '/api/child-nudges'         && method === 'GET')  return withAuth(request, auth, env, handleGetChildNudges);

--- a/worker/src/lib/familyAudit.test.ts
+++ b/worker/src/lib/familyAudit.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getMonthKey, getMonthStartEpoch, pickFlaggedChild, buildRuleBasedFamilyAudit,
+  type ChildMonthSignal,
+} from './familyAudit.js';
+
+describe('getMonthKey', () => {
+  it('formats a July 2026 date as 2026-07', () => {
+    expect(getMonthKey(new Date(Date.UTC(2026, 6, 7)))).toBe('2026-07');
+  });
+  it('pads single-digit months', () => {
+    expect(getMonthKey(new Date(Date.UTC(2026, 0, 15)))).toBe('2026-01');
+  });
+});
+
+describe('getMonthStartEpoch', () => {
+  it('returns the UTC epoch seconds for the 1st of the given month', () => {
+    const expected = Math.floor(Date.UTC(2026, 6, 1) / 1000);
+    expect(getMonthStartEpoch('2026-07')).toBe(expected);
+  });
+});
+
+describe('pickFlaggedChild', () => {
+  const base: ChildMonthSignal = {
+    child_id: 'c1', child_name: 'Logan',
+    available_balance_pence: 0, goals_locked_pence: 0,
+    planning_horizon: 50, responsibility_score: 90,
+  };
+
+  it('returns null for an empty signal list', () => {
+    expect(pickFlaggedChild([])).toBeNull();
+  });
+
+  it('prioritises Pillar 5 when a child has a surplus balance over £100', () => {
+    const signals = [base, { ...base, child_id: 'c2', child_name: 'Mia', available_balance_pence: 10001 }];
+    const result = pickFlaggedChild(signals);
+    expect(result).toEqual({ child_id: 'c2', child_name: 'Mia', pillar: 'PILLAR_5_SOCIAL_RESPONSIBILITY' });
+  });
+
+  it('falls to Pillar 3 when planning horizon is low and no surplus exists', () => {
+    const signals = [base, { ...base, child_id: 'c2', child_name: 'Mia', planning_horizon: 10 }];
+    const result = pickFlaggedChild(signals);
+    expect(result).toEqual({ child_id: 'c2', child_name: 'Mia', pillar: 'PILLAR_3_OPPORTUNITY_COST' });
+  });
+
+  it('falls to Pillar 1 when responsibility score is low', () => {
+    const signals = [base, { ...base, child_id: 'c2', child_name: 'Mia', responsibility_score: 40 }];
+    const result = pickFlaggedChild(signals);
+    expect(result).toEqual({ child_id: 'c2', child_name: 'Mia', pillar: 'PILLAR_1_LABOUR_VALUE' });
+  });
+
+  it('defaults to Pillar 4, picking the highest planning horizon, when no other signal fires', () => {
+    const signals = [base, { ...base, child_id: 'c2', child_name: 'Mia', planning_horizon: 80 }];
+    const result = pickFlaggedChild(signals);
+    expect(result).toEqual({ child_id: 'c2', child_name: 'Mia', pillar: 'PILLAR_4_CAPITAL_MANAGEMENT' });
+  });
+
+  it('treats a single child as its own subject with no comparison', () => {
+    const result = pickFlaggedChild([base]);
+    expect(result?.child_id).toBe('c1');
+  });
+});
+
+describe('buildRuleBasedFamilyAudit', () => {
+  const totals = { total_earned_pence: 5000, total_spent_pence: 2000, total_saved_pence: 1500, total_given_pence: 500 };
+
+  it('names the correct Pillar for each flagged pillar type', () => {
+    const cases: Array<[ChildMonthSignal['planning_horizon'] extends never ? never : string, string]> = [] as never;
+    const pillars = ['PILLAR_5_SOCIAL_RESPONSIBILITY', 'PILLAR_3_OPPORTUNITY_COST', 'PILLAR_1_LABOUR_VALUE', 'PILLAR_4_CAPITAL_MANAGEMENT'] as const;
+    for (const pillar of pillars) {
+      const content = buildRuleBasedFamilyAudit(totals, { child_id: 'c1', child_name: 'Logan', pillar }, 'Thomson');
+      expect(content.behavioral_root).toContain(
+        pillar === 'PILLAR_5_SOCIAL_RESPONSIBILITY' ? 'Pillar 5' :
+        pillar === 'PILLAR_3_OPPORTUNITY_COST'      ? 'Pillar 3' :
+        pillar === 'PILLAR_1_LABOUR_VALUE'          ? 'Pillar 1' : 'Pillar 4'
+      );
+      expect(content.observation).toContain('Logan') ;
+      expect(content.the_action.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/worker/src/lib/familyAudit.ts
+++ b/worker/src/lib/familyAudit.ts
@@ -1,0 +1,119 @@
+//
+// Pure, DB-free logic for the monthly Family Audit (Phase 5). Kept separate
+// from the route handler so the flagged-child priority ladder and the
+// rule-based fallback text can be unit tested without a D1 binding.
+
+export function getMonthKey(date: Date): string {
+  const y = date.getUTCFullYear();
+  const m = String(date.getUTCMonth() + 1).padStart(2, '0');
+  return `${y}-${m}`;
+}
+
+export function getMonthStartEpoch(monthKey: string): number {
+  const [y, m] = monthKey.split('-').map(Number);
+  return Math.floor(Date.UTC(y, m - 1, 1) / 1000);
+}
+
+export interface ChildMonthSignal {
+  child_id: string;
+  child_name: string;
+  available_balance_pence: number;
+  goals_locked_pence: number;
+  planning_horizon: number | null;      // 0–100 | null (no goals/balance yet)
+  responsibility_score: number | null;  // first-time pass rate, 0–100 | null
+}
+
+export type FlaggedPillar =
+  | 'PILLAR_5_SOCIAL_RESPONSIBILITY'
+  | 'PILLAR_3_OPPORTUNITY_COST'
+  | 'PILLAR_1_LABOUR_VALUE'
+  | 'PILLAR_4_CAPITAL_MANAGEMENT';
+
+export interface FlaggedChild {
+  child_id:   string;
+  child_name: string;
+  pillar:     FlaggedPillar;
+}
+
+/**
+ * Picks the one child whose pattern most needs a parent's attention this
+ * month, using the same Pillar-priority ladder as the per-child weekly
+ * briefing's buildRuleBasedBriefing (insights.ts): surplus/Pillar 5 first,
+ * then opportunity cost, then labour value, defaulting to capital
+ * management (the best performer) when nothing else fires.
+ */
+export function pickFlaggedChild(signals: ChildMonthSignal[]): FlaggedChild | null {
+  if (signals.length === 0) return null;
+
+  const surplus = signals.find(s =>
+    s.available_balance_pence > 10000 ||
+    (s.goals_locked_pence === 0 && s.available_balance_pence > 0)
+  );
+  if (surplus) {
+    return { child_id: surplus.child_id, child_name: surplus.child_name, pillar: 'PILLAR_5_SOCIAL_RESPONSIBILITY' };
+  }
+
+  const spendHeavy = signals.find(s => (s.planning_horizon ?? 50) < 20);
+  if (spendHeavy) {
+    return { child_id: spendHeavy.child_id, child_name: spendHeavy.child_name, pillar: 'PILLAR_3_OPPORTUNITY_COST' };
+  }
+
+  const struggling = signals.find(s => (s.responsibility_score ?? 100) < 60);
+  if (struggling) {
+    return { child_id: struggling.child_id, child_name: struggling.child_name, pillar: 'PILLAR_1_LABOUR_VALUE' };
+  }
+
+  const best = [...signals].sort((a, b) => (b.planning_horizon ?? 0) - (a.planning_horizon ?? 0))[0];
+  return { child_id: best.child_id, child_name: best.child_name, pillar: 'PILLAR_4_CAPITAL_MANAGEMENT' };
+}
+
+export interface FamilyTotals {
+  total_earned_pence: number;
+  total_spent_pence:  number;
+  total_saved_pence:  number;
+  total_given_pence:  number;
+}
+
+export interface FamilyAuditContent {
+  observation:     string;
+  behavioral_root: string;
+  the_action:      string;
+}
+
+/** Deterministic fallback text — used when the LLM call errors or times out. */
+export function buildRuleBasedFamilyAudit(
+  totals:      FamilyTotals,
+  flagged:     FlaggedChild,
+  familyName:  string,
+): FamilyAuditContent {
+  const earnedDisplay = `£${(totals.total_earned_pence / 100).toFixed(2)}`;
+  const spentDisplay  = `£${(totals.total_spent_pence  / 100).toFixed(2)}`;
+
+  switch (flagged.pillar) {
+    case 'PILLAR_5_SOCIAL_RESPONSIBILITY':
+      return {
+        observation:     `We've noted that the ${familyName} family earned ${earnedDisplay} this month, and ${flagged.child_name} is carrying a meaningful surplus balance.`,
+        behavioral_root: 'Pillar 5 — Social Responsibility: a funded surplus without a social allocation represents idle capital in behavioural finance terms.',
+        the_action:      `You might consider introducing a Social Allocation target for ${flagged.child_name} (e.g. 5–10% of surplus) this month.`,
+      };
+    case 'PILLAR_3_OPPORTUNITY_COST':
+      return {
+        observation:     `We've noted that ${flagged.child_name}'s Planning Horizon is low this month, with ${spentDisplay} spent across the family overall.`,
+        behavioral_root: 'Pillar 3 — Opportunity Cost: a low Planning Horizon at this stage indicates a preference for immediate value over compounding future returns.',
+        the_action:      `You might consider asking ${flagged.child_name} what goal one recent purchase could have moved forward instead.`,
+      };
+    case 'PILLAR_1_LABOUR_VALUE':
+      return {
+        observation:     `We've noted a dip in task consistency or first-time pass rate for ${flagged.child_name} this month.`,
+        behavioral_root: 'Pillar 1 — Labour Value: variable-quality weeks are part of every growth cycle; the productive question is whether the cause is task scope, motivation, or reward structure.',
+        the_action:      `You might consider a short check-in with ${flagged.child_name} about which tasks feel hardest right now.`,
+      };
+    case 'PILLAR_4_CAPITAL_MANAGEMENT':
+    default:
+      return {
+        observation:     `We've noted a stable month for the ${familyName} family — ${earnedDisplay} earned in total, with ${flagged.child_name} showing the strongest Planning Horizon.`,
+        behavioral_root: 'Pillar 4 — Capital Management: sustained stability at high performance is the optimal condition for introducing compound growth concepts.',
+        the_action:      `You might consider modelling with ${flagged.child_name} what a 5% annual return would look like on their current savings balance.`,
+      };
+  }
+}

--- a/worker/src/lib/ledgerBalance.ts
+++ b/worker/src/lib/ledgerBalance.ts
@@ -1,0 +1,29 @@
+// worker/src/lib/ledgerBalance.ts
+//
+// Canonical "available balance" formula for a child's ledger. Single
+// source of truth — insights.ts and family-audit.ts both call this instead
+// of duplicating the SQL, after a 2026-07 audit found each had drifted
+// from the correct formula independently (see
+// docs/superpowers/specs/2026-07-07-balance-math-shared-fix-design.md).
+
+import type { D1Database } from '@cloudflare/workers-types';
+
+export async function getAvailableBalancePence(
+  db: D1Database,
+  familyId: string,
+  childId: string,
+): Promise<number> {
+  const row = await db.prepare(`
+    SELECT COALESCE(SUM(
+      CASE entry_type
+        WHEN 'credit'   THEN amount
+        WHEN 'reversal' THEN -amount
+        WHEN 'payment'  THEN -amount
+        ELSE 0
+      END
+    ), 0) AS bal
+    FROM ledger WHERE family_id = ? AND child_id = ?
+      AND verification_status IN ('verified_auto', 'verified_manual')
+  `).bind(familyId, childId).first<{ bal: number }>();
+  return row?.bal ?? 0;
+}

--- a/worker/src/routes/family-audit.ts
+++ b/worker/src/routes/family-audit.ts
@@ -31,15 +31,7 @@ export async function handleGetFamilyAudit(request: Request, env: Env): Promise<
   const monthKey   = getMonthKey(new Date());
   const monthStart = getMonthStartEpoch(monthKey);
 
-  const cached = await env.DB.prepare(`
-    SELECT total_earned_pence, total_spent_pence, total_saved_pence, total_given_pence,
-           flagged_child_id, flagged_pillar, observation, behavioral_root, the_action, source
-    FROM family_audit_snapshots WHERE family_id = ? AND month_key = ?
-  `).bind(family_id, monthKey).first<{
-    total_earned_pence: number; total_spent_pence: number; total_saved_pence: number; total_given_pence: number;
-    flagged_child_id: string; flagged_pillar: string;
-    observation: string; behavioral_root: string; the_action: string; source: 'rule_based' | 'ai';
-  }>();
+  const cached = await getCachedSnapshot(env, family_id, monthKey);
 
   if (cached) {
     return json({
@@ -104,8 +96,15 @@ export async function handleGetFamilyAudit(request: Request, env: Env): Promise<
 
     const [balRow, goalsRow, completionRow] = await Promise.all([
       env.DB.prepare(`
-        SELECT COALESCE(SUM(CASE WHEN entry_type='credit' THEN amount ELSE -amount END),0) AS bal
+        SELECT COALESCE(SUM(
+          CASE entry_type
+            WHEN 'credit'  THEN amount
+            WHEN 'payment' THEN -amount
+            ELSE 0
+          END
+        ),0) AS bal
         FROM ledger WHERE family_id=? AND child_id=?
+          AND verification_status IN ('verified_auto','verified_manual')
       `).bind(family_id, childId).first<{ bal: number }>(),
 
       env.DB.prepare(`
@@ -140,7 +139,7 @@ export async function handleGetFamilyAudit(request: Request, env: Env): Promise<
   const content = await generateFamilyAuditContent(env, family_id, totals, flagged, familyCtx.family_name);
 
   await env.DB.prepare(`
-    INSERT INTO family_audit_snapshots
+    INSERT OR IGNORE INTO family_audit_snapshots
       (family_id, month_key, total_earned_pence, total_spent_pence, total_saved_pence, total_given_pence,
        flagged_child_id, flagged_pillar, observation, behavioral_root, the_action, source)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -151,13 +150,40 @@ export async function handleGetFamilyAudit(request: Request, env: Env): Promise<
     content.observation, content.behavioral_root, content.the_action, content.source,
   ).run();
 
+  // Re-read from the cache table rather than returning `content` directly: if a concurrent
+  // request won the INSERT OR IGNORE race, this returns the winner's persisted text so the
+  // response stays consistent with what's actually cached.
+  const persisted = await getCachedSnapshot(env, family_id, monthKey);
+
   return json({
     month: monthKey,
-    totals,
-    flagged_child_id: flagged.child_id,
-    flagged_pillar:   flagged.pillar,
-    ...content,
+    totals: persisted ? {
+      total_earned_pence: persisted.total_earned_pence,
+      total_spent_pence:  persisted.total_spent_pence,
+      total_saved_pence:  persisted.total_saved_pence,
+      total_given_pence:  persisted.total_given_pence,
+    } : totals,
+    flagged_child_id: persisted?.flagged_child_id ?? flagged.child_id,
+    flagged_pillar:   persisted?.flagged_pillar   ?? flagged.pillar,
+    observation:      persisted?.observation      ?? content.observation,
+    behavioral_root:  persisted?.behavioral_root  ?? content.behavioral_root,
+    the_action:       persisted?.the_action       ?? content.the_action,
+    source:           persisted?.source           ?? content.source,
   });
+}
+
+interface CachedFamilyAuditSnapshot {
+  total_earned_pence: number; total_spent_pence: number; total_saved_pence: number; total_given_pence: number;
+  flagged_child_id: string; flagged_pillar: string;
+  observation: string; behavioral_root: string; the_action: string; source: 'rule_based' | 'ai';
+}
+
+async function getCachedSnapshot(env: Env, family_id: string, monthKey: string): Promise<CachedFamilyAuditSnapshot | null> {
+  return env.DB.prepare(`
+    SELECT total_earned_pence, total_spent_pence, total_saved_pence, total_given_pence,
+           flagged_child_id, flagged_pillar, observation, behavioral_root, the_action, source
+    FROM family_audit_snapshots WHERE family_id = ? AND month_key = ?
+  `).bind(family_id, monthKey).first<CachedFamilyAuditSnapshot>();
 }
 
 interface GeneratedContent {

--- a/worker/src/routes/family-audit.ts
+++ b/worker/src/routes/family-audit.ts
@@ -1,0 +1,275 @@
+// worker/src/routes/family-audit.ts
+//
+// GET /api/family-audit?family_id=
+//
+// Monthly, family-wide spending/earning/saving rollup for parents.
+// Cached one row per family per calendar month in family_audit_snapshots —
+// on cache miss, calls gpt-4o-mini for narrative text (with a rule-based
+// fallback on error/timeout), mirroring the per-child weekly briefing
+// pattern in insights.ts.
+
+import type { Env } from '../types.js';
+import { json, error } from '../lib/response.js';
+import { JwtPayload } from '../lib/jwt.js';
+import { captureAiGeneration } from '../lib/posthog.js';
+import { getFamilyContext } from '../lib/intelligence.js';
+import {
+  getMonthKey, getMonthStartEpoch, pickFlaggedChild, buildRuleBasedFamilyAudit,
+  ChildMonthSignal, FamilyTotals, FlaggedChild,
+} from '../lib/familyAudit.js';
+
+type AuthedRequest = Request & { auth: JwtPayload };
+
+export async function handleGetFamilyAudit(request: Request, env: Env): Promise<Response> {
+  const auth      = (request as AuthedRequest).auth;
+  const family_id = new URL(request.url).searchParams.get('family_id');
+
+  if (!family_id) return error('family_id required');
+  if (family_id !== auth.family_id) return error('Forbidden', 403);
+  if (auth.role === 'child') return error('Forbidden', 403);
+
+  const monthKey   = getMonthKey(new Date());
+  const monthStart = getMonthStartEpoch(monthKey);
+
+  const cached = await env.DB.prepare(`
+    SELECT total_earned_pence, total_spent_pence, total_saved_pence, total_given_pence,
+           flagged_child_id, flagged_pillar, observation, behavioral_root, the_action, source
+    FROM family_audit_snapshots WHERE family_id = ? AND month_key = ?
+  `).bind(family_id, monthKey).first<{
+    total_earned_pence: number; total_spent_pence: number; total_saved_pence: number; total_given_pence: number;
+    flagged_child_id: string; flagged_pillar: string;
+    observation: string; behavioral_root: string; the_action: string; source: 'rule_based' | 'ai';
+  }>();
+
+  if (cached) {
+    return json({
+      month: monthKey,
+      totals: {
+        total_earned_pence: cached.total_earned_pence,
+        total_spent_pence:  cached.total_spent_pence,
+        total_saved_pence:  cached.total_saved_pence,
+        total_given_pence:  cached.total_given_pence,
+      },
+      flagged_child_id: cached.flagged_child_id,
+      flagged_pillar:   cached.flagged_pillar,
+      observation:      cached.observation,
+      behavioral_root:  cached.behavioral_root,
+      the_action:       cached.the_action,
+      source:           cached.source,
+    });
+  }
+
+  const familyCtx = await getFamilyContext(env.DB, family_id);
+  if (familyCtx.child_ids.length === 0) return json({ month: monthKey, is_empty: true });
+
+  const placeholders = familyCtx.child_ids.map(() => '?').join(',');
+
+  const [earnedRow, spentRow, savedRow, givenRow] = await Promise.all([
+    env.DB.prepare(`
+      SELECT COALESCE(SUM(amount),0) AS total FROM ledger
+      WHERE family_id=? AND entry_type='credit' AND created_at >= ? AND child_id IN (${placeholders})
+    `).bind(family_id, monthStart, ...familyCtx.child_ids).first<{ total: number }>(),
+
+    env.DB.prepare(`
+      SELECT COALESCE(SUM(amount),0) AS total FROM spending
+      WHERE family_id=? AND spent_at >= ? AND child_id IN (${placeholders})
+    `).bind(family_id, monthStart, ...familyCtx.child_ids).first<{ total: number }>(),
+
+    env.DB.prepare(`
+      SELECT COALESCE(SUM(delta),0) AS total FROM jar_movements
+      WHERE family_id=? AND jar='save' AND kind='allocation' AND created_at >= ? AND child_id IN (${placeholders})
+    `).bind(family_id, monthStart, ...familyCtx.child_ids).first<{ total: number }>(),
+
+    env.DB.prepare(`
+      SELECT COALESCE(SUM(amount),0) AS total FROM give_requests
+      WHERE family_id=? AND status='fulfilled' AND fulfilled_at >= ? AND child_id IN (${placeholders})
+    `).bind(family_id, monthStart, ...familyCtx.child_ids).first<{ total: number }>(),
+  ]);
+
+  const totals: FamilyTotals = {
+    total_earned_pence: earnedRow?.total ?? 0,
+    total_spent_pence:  spentRow?.total  ?? 0,
+    total_saved_pence:  savedRow?.total  ?? 0,
+    total_given_pence:  givenRow?.total  ?? 0,
+  };
+
+  if (totals.total_earned_pence === 0 && totals.total_spent_pence === 0) {
+    return json({ month: monthKey, is_empty: true });
+  }
+
+  const signals: ChildMonthSignal[] = [];
+  for (let i = 0; i < familyCtx.child_ids.length; i++) {
+    const childId   = familyCtx.child_ids[i];
+    const childName = familyCtx.child_names[i];
+
+    const [balRow, goalsRow, completionRow] = await Promise.all([
+      env.DB.prepare(`
+        SELECT COALESCE(SUM(CASE WHEN entry_type='credit' THEN amount ELSE -amount END),0) AS bal
+        FROM ledger WHERE family_id=? AND child_id=?
+      `).bind(family_id, childId).first<{ bal: number }>(),
+
+      env.DB.prepare(`
+        SELECT COALESCE(SUM(target_amount - current_saved_pence),0) AS locked
+        FROM goals WHERE family_id=? AND child_id=? AND archived=0 AND target_amount > current_saved_pence
+      `).bind(family_id, childId).first<{ locked: number }>().catch(() => ({ locked: 0 })),
+
+      env.DB.prepare(`
+        SELECT COUNT(*) AS total, SUM(CASE WHEN attempt_count=1 THEN 1 ELSE 0 END) AS first_time
+        FROM completions WHERE family_id=? AND child_id=? AND status='completed' AND resolved_at >= ?
+      `).bind(family_id, childId, monthStart).first<{ total: number; first_time: number }>(),
+    ]);
+
+    const availableBal    = Math.max(0, balRow?.bal ?? 0);
+    const goalsLocked     = goalsRow?.locked ?? 0;
+    const totalHeld       = availableBal + goalsLocked;
+    const totalCompleted  = completionRow?.total ?? 0;
+
+    signals.push({
+      child_id:                childId,
+      child_name:              childName,
+      available_balance_pence: availableBal,
+      goals_locked_pence:      goalsLocked,
+      planning_horizon:        totalHeld > 0 ? Math.round((goalsLocked / totalHeld) * 100) : null,
+      responsibility_score:    totalCompleted > 0 ? Math.round(((completionRow?.first_time ?? 0) / totalCompleted) * 100) : null,
+    });
+  }
+
+  const flagged = pickFlaggedChild(signals);
+  if (!flagged) return json({ month: monthKey, is_empty: true });
+
+  const content = await generateFamilyAuditContent(env, family_id, totals, flagged, familyCtx.family_name);
+
+  await env.DB.prepare(`
+    INSERT INTO family_audit_snapshots
+      (family_id, month_key, total_earned_pence, total_spent_pence, total_saved_pence, total_given_pence,
+       flagged_child_id, flagged_pillar, observation, behavioral_root, the_action, source)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).bind(
+    family_id, monthKey,
+    totals.total_earned_pence, totals.total_spent_pence, totals.total_saved_pence, totals.total_given_pence,
+    flagged.child_id, flagged.pillar,
+    content.observation, content.behavioral_root, content.the_action, content.source,
+  ).run();
+
+  return json({
+    month: monthKey,
+    totals,
+    flagged_child_id: flagged.child_id,
+    flagged_pillar:   flagged.pillar,
+    ...content,
+  });
+}
+
+interface GeneratedContent {
+  observation:     string;
+  behavioral_root: string;
+  the_action:      string;
+  source:          'ai' | 'rule_based';
+}
+
+async function generateFamilyAuditContent(
+  env:        Env,
+  familyId:   string,
+  totals:     FamilyTotals,
+  flagged:    FlaggedChild,
+  familyName: string,
+): Promise<GeneratedContent> {
+  const systemPrompt = `You are the 'Orchard Lead', a collaborative financial coach for parents. \
+Your goal is to analyse a family's month of financial behaviour data across ALL of their children \
+combined, and produce a professional family-wide executive briefing grounded in the Morechard \
+Financial Literacy Matrix.
+
+THE LITERACY MATRIX (your mandatory syllabus):
+- Pillar 1 — Labour Value ("The Toil"): Money is stored energy; link tasks to Purchasing Power.
+- Pillar 2 — Delayed Gratification ("The Season"): The wait for a bigger harvest; Needs vs. Wants.
+- Pillar 3 — Opportunity Cost ("Pruning the Path"): Every "Yes" to a small spend is a "No" to a major goal.
+- Pillar 4 — Capital Management ("The Savings Grove"): Compound Interest (Growth) and Inflation (Decay).
+- Pillar 5 — Social Responsibility ("The Overhang"): Using surplus harvest to contribute to the Community Forest.
+
+You have already been told which child and which Pillar to focus on — do not choose a different one.
+Reference the flagged child by name and ground the observation in the family totals provided.
+
+CONSTRAINTS:
+- Use first-person plural ("We", "Us", "Our") throughout.
+- Tone: supportive, egalitarian, collaborative. No chatbot fluff or excessive praise.
+- Choice Architecture: present options for the parent ("You might consider..."); never dictate.
+- UK English: "Wellbeing", "Pence", "Organise", "Behaviour", "Recognise".
+- behavioral_root MUST name the given Pillar explicitly.
+- Respond ONLY with a valid JSON object. No markdown, no commentary, no extra fields.
+
+Response schema (strict):
+{
+  "observation": "<1 sentence — a statement of fact based on the family totals and flagged child>",
+  "behavioral_root": "<1 sentence — names the given Pillar and links it to a future financial literacy outcome>",
+  "the_action": "<1 sentence — a concrete option for the parent, framed as a choice>"
+}`;
+
+  const userPrompt = JSON.stringify({
+    family_name:   familyName,
+    totals,
+    flagged_child: flagged.child_name,
+    flagged_pillar: flagged.pillar,
+  });
+
+  const messages = [
+    { role: 'system', content: systemPrompt },
+    { role: 'user',   content: userPrompt },
+  ];
+  const traceId = crypto.randomUUID();
+  const t0      = Date.now();
+
+  try {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type':  'application/json',
+        'Authorization': `Bearer ${env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model:           'gpt-4o-mini',
+        messages,
+        max_tokens:      350,
+        response_format: { type: 'json_object' },
+      }),
+      signal: AbortSignal.timeout(10000),
+    });
+
+    if (!res.ok) throw new Error(`OpenAI ${res.status}`);
+
+    const data   = await res.json() as { choices: Array<{ message: { content: string } }> };
+    const raw    = data.choices[0]?.message?.content ?? '';
+    const parsed = JSON.parse(raw) as Partial<GeneratedContent>;
+
+    if (!parsed.observation || !parsed.behavioral_root || !parsed.the_action) {
+      throw new Error('Incomplete AI response schema');
+    }
+
+    captureAiGeneration(env, {
+      distinctId:     familyId,
+      traceId,
+      spanName:       'family_audit',
+      model:          'gpt-4o-mini',
+      provider:       'openai',
+      input:          messages,
+      outputText:     raw,
+      latencySeconds: (Date.now() - t0) / 1000,
+    });
+
+    return { observation: parsed.observation, behavioral_root: parsed.behavioral_root, the_action: parsed.the_action, source: 'ai' };
+  } catch (err) {
+    captureAiGeneration(env, {
+      distinctId:     familyId,
+      traceId,
+      spanName:       'family_audit',
+      model:          'gpt-4o-mini',
+      provider:       'openai',
+      input:          messages,
+      latencySeconds: (Date.now() - t0) / 1000,
+      isError:        true,
+      errorMessage:   err instanceof Error ? err.message : String(err),
+    });
+
+    const fallback = buildRuleBasedFamilyAudit(totals, flagged, familyName);
+    return { ...fallback, source: 'rule_based' };
+  }
+}

--- a/worker/src/routes/family-audit.ts
+++ b/worker/src/routes/family-audit.ts
@@ -219,7 +219,10 @@ CONSTRAINTS:
 - Use first-person plural ("We", "Us", "Our") throughout.
 - Tone: supportive, egalitarian, collaborative. No chatbot fluff or excessive praise.
 - Choice Architecture: present options for the parent ("You might consider..."); never dictate.
-- UK English: "Wellbeing", "Pence", "Organise", "Behaviour", "Recognise".
+- UK English: "Wellbeing", "Organise", "Behaviour", "Recognise".
+- Currency: every value in "totals" is in pence (100 pence = £1). ALWAYS convert to pounds and
+  write it the way a person actually talks — "£8.00", "£21.50" — never write a raw pence figure
+  or the word "pence" anywhere in your response.
 - behavioral_root MUST name the given Pillar explicitly.
 - Respond ONLY with a valid JSON object. No markdown, no commentary, no extra fields.
 
@@ -230,9 +233,16 @@ Response schema (strict):
   "the_action": "<1 sentence — a concrete option for the parent, framed as a choice>"
 }`;
 
+  const formatPounds = (pence: number) => `£${(pence / 100).toFixed(2)}`;
+
   const userPrompt = JSON.stringify({
-    family_name:   familyName,
-    totals,
+    family_name: familyName,
+    totals_formatted: {
+      earned: formatPounds(totals.total_earned_pence),
+      spent:  formatPounds(totals.total_spent_pence),
+      saved:  formatPounds(totals.total_saved_pence),
+      given:  formatPounds(totals.total_given_pence),
+    },
     flagged_child: flagged.child_name,
     flagged_pillar: flagged.pillar,
   });

--- a/worker/src/routes/family-audit.ts
+++ b/worker/src/routes/family-audit.ts
@@ -17,6 +17,7 @@ import {
   getMonthKey, getMonthStartEpoch, pickFlaggedChild, buildRuleBasedFamilyAudit,
   ChildMonthSignal, FamilyTotals, FlaggedChild,
 } from '../lib/familyAudit.js';
+import { getAvailableBalancePence } from '../lib/ledgerBalance.js';
 
 type AuthedRequest = Request & { auth: JwtPayload };
 
@@ -94,18 +95,8 @@ export async function handleGetFamilyAudit(request: Request, env: Env): Promise<
     const childId   = familyCtx.child_ids[i];
     const childName = familyCtx.child_names[i];
 
-    const [balRow, goalsRow, completionRow] = await Promise.all([
-      env.DB.prepare(`
-        SELECT COALESCE(SUM(
-          CASE entry_type
-            WHEN 'credit'  THEN amount
-            WHEN 'payment' THEN -amount
-            ELSE 0
-          END
-        ),0) AS bal
-        FROM ledger WHERE family_id=? AND child_id=?
-          AND verification_status IN ('verified_auto','verified_manual')
-      `).bind(family_id, childId).first<{ bal: number }>(),
+    const [availableBalRaw, goalsRow, completionRow] = await Promise.all([
+      getAvailableBalancePence(env.DB, family_id, childId),
 
       env.DB.prepare(`
         SELECT COALESCE(SUM(target_amount - current_saved_pence),0) AS locked
@@ -118,7 +109,7 @@ export async function handleGetFamilyAudit(request: Request, env: Env): Promise<
       `).bind(family_id, childId, monthStart).first<{ total: number; first_time: number }>(),
     ]);
 
-    const availableBal    = Math.max(0, balRow?.bal ?? 0);
+    const availableBal    = Math.max(0, availableBalRaw);
     const goalsLocked     = goalsRow?.locked ?? 0;
     const totalHeld       = availableBal + goalsLocked;
     const totalCompleted  = completionRow?.total ?? 0;

--- a/worker/src/routes/insights.ts
+++ b/worker/src/routes/insights.ts
@@ -26,6 +26,7 @@ import { JwtPayload } from '../lib/jwt.js';
 import { captureAiGeneration } from '../lib/posthog.js';
 import { getFamilyContext } from '../lib/intelligence.js';
 import { computeJarSignals, JarSignals } from '../lib/jar-balance.js';
+import { getAvailableBalancePence } from '../lib/ledgerBalance.js';
 
 type AuthedRequest = Request & { auth: JwtPayload };
 
@@ -169,7 +170,7 @@ export async function handleInsights(request: Request, env: Env): Promise<Respon
   }
 
   // ── 5. Financial Metrics ─────────────────────────────────────────────────
-  const [earnedRow, spentRow, savedRow, balanceRow, lifetimeRow, goalsRow] = await Promise.all([
+  const [earnedRow, spentRow, savedRow, lifetimeRow, goalsRow] = await Promise.all([
     env.DB.prepare(`
       SELECT COALESCE(SUM(amount), 0) AS total FROM ledger
       WHERE family_id = ? AND child_id = ? AND entry_type = 'credit'
@@ -192,15 +193,6 @@ export async function handleInsights(request: Request, env: Env): Promise<Respon
       .first<{ total: number }>()
       .catch(() => ({ total: 0 })),
 
-    // Available balance: sum of credits minus debits from ledger
-    env.DB.prepare(`
-      SELECT
-        COALESCE(SUM(CASE WHEN entry_type = 'credit' THEN amount ELSE -amount END), 0) AS available
-      FROM ledger
-      WHERE family_id = ? AND child_id = ?
-    `).bind(family_id, effectiveChildId)
-      .first<{ available: number }>(),
-
     // Lifetime earned
     env.DB.prepare(`
       SELECT COALESCE(SUM(amount), 0) AS total FROM ledger
@@ -222,7 +214,7 @@ export async function handleInsights(request: Request, env: Env): Promise<Respon
   const totalEarned   = earnedRow?.total     ?? 0;
   const totalSpent    = spentRow?.total      ?? 0;
   const totalSaved    = savedRow?.total      ?? 0;
-  const availableBal  = balanceRow?.available ?? 0;
+  const availableBal  = await getAvailableBalancePence(env.DB, family_id, effectiveChildId);
   const lifetimeEarned = lifetimeRow?.total  ?? 0;
   const goalsLocked   = goalsRow?.locked     ?? 0;
 


### PR DESCRIPTION
## Summary
- Adds a monthly, family-wide AI-generated "Family Audit" card to the parent Insights tab (Phase 5 roadmap item), aggregating earned/spent/saved/given across all children with an AI-flagged child + Pillar recommendation, cached per family/month with a rule-based fallback on LLM error/timeout.
- Standardizes the EU AI Act Article 50 "AI-generated" disclosure pill across all three AI-authored surfaces (parent weekly briefing, new Family Audit card, child nudge banner) via a shared `AiDisclosurePill` component.
- Post-deploy UI polish from live review: period toggle moved to the thumb zone (matches the app's existing bottom-CTA pattern), the two AI cards grouped adjacent, header styling unified across all mentor card variants, and a currency-phrasing bug in the AI prompt fixed ("800 pence" → "£8.00").
- Drops "seasonal event linking" from the original roadmap item — no DOB or events data exists to support it.

**⚠️ Already deployed to production** (migration applied to `morechard`, worker deployed) at the user's explicit request, since visual verification required a live environment. This PR is being opened for the permanent record/review, not as a pre-deploy gate.

## Test plan
- [x] 208 worker tests passing, 70 app tests passing
- [x] Every task individually reviewed (spec + quality) via subagent-driven-development
- [x] Final whole-branch review — 2 Important findings (non-idempotent cache write, incorrect per-child balance CASE expression) found and fixed
- [x] Manually verified end-to-end in browser against seeded demo data (API responses, cache hit/miss, rendered UI, no new console errors)
- [x] Production migration applied and verified; worker deploy confirmed live via smoke test

## Known follow-ups (not in this PR)
- `total_earned_pence` and related balance queries don't filter `verification_status` — pre-existing gap shared with `insights.ts`, deferred to a joint fix.
- `DiscoveryCard` ("Getting to know X") is static template text but product intent is for it to be genuinely AI-generated — needs its own design pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)